### PR TITLE
Added PurgeMongDB function in aDMIX

### DIFF
--- a/admix/admix.py
+++ b/admix/admix.py
@@ -18,6 +18,7 @@ from admix.tasks.update_runDB import UpdateRunDBMongoDB
 from admix.tasks.init_transfers_with_mongodb import InitTransfersMongoDB
 from admix.tasks.download_with_mongodb import DownloadMongoDB
 from admix.tasks.clear_transfers_with_mongdb import ClearTransfersMongoDB
+from admix.tasks.purge_with_mongodb import PurgeMongoDB
 
 def version():
     import admix
@@ -47,6 +48,10 @@ def your_admix():
                         help="Select a range of runs by timestamps <Date>_<Time>-<Date>_<Time>")
     parser.add_argument('--source', nargs='*', dest='source', type=str,
                         help="Select data according to a certain source(s)")
+    parser.add_argument('--type', nargs='*', dest='type', type=str,
+                        help="Select data according to a certain type")
+    parser.add_argument('--hash', nargs='*', dest='hash', type=str,
+                        help="Select data according to a certain hash")
     parser.add_argument('--tag', nargs='*', dest='tag', type=str,
                         help="Select data according to a certain tag(s)")
     parser.add_argument('--destination', dest='destination', type=str,
@@ -55,7 +60,8 @@ def your_admix():
                         help="Select your RSE from where to download data")
     parser.add_argument('--lifetime', dest='lifetime', type=str,
                         help="Select your RSE from where to download data")
-
+    parser.add_argument('--force', default=False, action="store_true",
+                        help="Enforce your action. Be aware of the application!")
     args = parser.parse_args()
 
     #We make the individual arguments global available right after aDMIX starts:
@@ -68,6 +74,9 @@ def your_admix():
     helper.make_global("no_db_update", args.no_update)
     helper.make_global("source", args.source)
     helper.make_global("tag", args.tag)
+    helper.make_global("type", args.type)
+    helper.make_global("hash", args.hash)
+    helper.make_global("force", args.force)
 
     #Pre tests:
     # admix host configuration must match the hostname:

--- a/admix/helper/helper.py
+++ b/admix/helper/helper.py
@@ -13,6 +13,11 @@ import numpy as np
 global_dictionary = {}
 
 def make_global(dict_key, dict_value):
+    """Function: make_global
+    Provides a global dictionary across aDMIX
+    :param dict_key: The name of the variable
+    :param dict_value: The value of the variable
+    """
     global global_dictionary
 
     if dict_key not in global_dictionary:
@@ -69,7 +74,13 @@ def run_number_converter_full(run_number=None):
     return nb_array
 
 def eval_run_numbers(run_numbers=None, run_number_min=None, run_number_max=None):
-
+    """Function: eval_run_numbers
+    Deals with several ways to hand over the timestamp/run names in aDMIX
+    1) <date>_<time> (Single)
+    2) <date>_<time>,<date>_<time> (Multiple)
+    :param timestamp: A string of timestamps what follows single, multiple criterion
+    :return list: A list of timestamps
+    """
     #test if run_numbers follows a certain structure:
     eval_nb_min = None
     eval_nb_max = None
@@ -112,7 +123,13 @@ def eval_run_numbers(run_numbers=None, run_number_min=None, run_number_max=None)
     return [eval_nb_min, eval_nb_max]
 
 def eval_run_timestamps(run_timestamps=None, run_timestamp_min=None, run_timestamp_max=None):
-
+    """Function: eval_run_timestamps
+    Deals with several ways to hand over the timestamp/run names in aDMIX
+    1) <date>_<time> (Single)
+    2) <date>_<time>,<date>_<time> (Multiple)
+    :param timestamp: A string of timestamps what follows single, multiple criterion
+    :return list: A list of timestamps
+    """
     eval_ts_min = None
     eval_ts_max = None
     if run_timestamps != None and run_timestamp_min != None and run_timestamp_max != None:
@@ -168,7 +185,13 @@ def eval_run_timestamps(run_timestamps=None, run_timestamp_min=None, run_timesta
 
 
 def run_timestamp_converter(timestamp = None):
-
+    """Function: run_timestamp_converter
+    Deals with several ways to hand over the timestamp/run names in aDMIX
+    1) <date>_<time> (Single)
+    2) <date>_<time>,<date>_<time> (Multiple)
+    :param timestamp: A string of timestamps what follows single, multiple criterion
+    :return list: A list of timestamps
+    """
     ts_list = []
     if timestamp != None:
         ts = timestamp.split(",")
@@ -196,7 +219,14 @@ def run_timestamp_converter(timestamp = None):
 
 
 def safeformat(str, **kwargs):
-    #https://stackoverflow.com/questions/17215400/python-format-string-unused-named-arguments
+    """Function safeformat
+    A quick python (3.2+) way to avoid errors with missing keywords in strings.
+    Taken from https://stackoverflow.com/questions/17215400/python-format-string-unused-named-arguments
+    :param str: The list of strings with brackets
+    :param **kwargs: Arguments to fill in the brackets
+    :return string: The string with filled brackets but leaves the ones untouched where no information is available
+    """
+
     class SafeDict(dict):
         def __missing__(self, key):
             return '{' + key + '}'
@@ -204,6 +234,11 @@ def safeformat(str, **kwargs):
     return str.format_map(replacements)
 
 def read_folder(path):
+    """Function: read_folder
+    Read a folder from the input path
+    :param path: String with valid path information
+    :return list: A list of [directory_path, folders, files] found in the path
+    """
     ret_folder = []
     ret_dirpath = []
     ret_files = []
@@ -215,8 +250,11 @@ def read_folder(path):
     return [ret_dirpath, ret_folder, ret_files]
 
 def run_name_converter(run_name=None):
-    #convert a comma separated list of the --name
-    #terminal input into a python  list
+    """Function: run_name_converter
+    convert a comma separated list of the --name terminal input into a python  list
+    :param run_name: A list of comma separated strings
+    :return list: A list of strings
+    """
 
     if run_name != None:
         run_name = run_name.replace(" ", "")
@@ -225,6 +263,13 @@ def run_name_converter(run_name=None):
     return run_name
 
 def check_valid_timestamp( timestamp=None):
+    """Function check_valid_timestamp
+    Check for the correct format of string timestamp
+    with format <date>_<time>
+
+    :param timestamp: A string timestamp (any format)
+    :return bool: True if pattern follows <date>_<time>, otherwise False
+    """
     #Check a valid timestamp scheme input
     # <date (YYMMDD)>_<time (hh:mm)>
     ts_valid = False
@@ -236,7 +281,13 @@ def check_valid_timestamp( timestamp=None):
     return ts_valid
 
 def string_to_datatime( time_='700101_0000', pattern='%y%m%d_%H%M'):
-        return datetime.datetime.strptime(time_, pattern)
+    """Function string_to_datetime
+    Lazy approach to create a datetime object from a string given a pattern
+    :param time: A timestamp string of your choice
+    :param pattern: The pattern what applies to the input of time
+    :return datetime: A datetime object of the timestampe
+    """
+    return datetime.datetime.strptime(time_, pattern)
 
 def functdef():
     try:
@@ -251,10 +302,18 @@ def functdef():
 
 #string_to_datatime
 def get_science_run(timestamp=datetime.datetime(1981, 11, 11, 5, 30)):
-    #Evaluate science run periods:
+    """Function get_science_run
+    This function evaluate (hardcoded) information about the science run
+    periods in XENON1T.
+    Note: We abandoned the concept science runs in data names and made use only
+    of the tagging system in the meta database. Use this function becomes
+    only necessary when dealing XENON1T data.
+    :param timestamp: A datetime object what holds the time of the run
+    :return string: One of both science run periods (000 or 001), if fails -1
+    """
 
     if timestamp == datetime.datetime(1981, 11, 11, 5, 30):
-        return "0"
+        return "-1"
 
     #1) Change from sc0 to sc1:
     dt0to1 = datetime.datetime(2017, 2, 2, 17, 40)
@@ -265,5 +324,5 @@ def get_science_run(timestamp=datetime.datetime(1981, 11, 11, 5, 30)):
     elif timestamp >= dt0to1:
         science_run = "001"
     else:
-        science_run = -1
+        science_run = "-1"
     return science_run

--- a/admix/tasks/purge_with_mongodb.py
+++ b/admix/tasks/purge_with_mongodb.py
@@ -1,0 +1,262 @@
+# -*- coding: utf-8 -*-
+import json
+import os
+import shutil
+from admix.helper import helper
+
+from admix.interfaces.database import ConnectMongoDB
+from admix.helper.decorator import Collector
+
+# get Rucio imports done:
+from admix.interfaces.rucio_dataformat import ConfigRucioDataFormat
+from admix.interfaces.rucio_summoner import RucioSummoner
+from admix.interfaces.destination import Destination
+from admix.interfaces.keyword import Keyword
+from admix.interfaces.templater import Templater
+
+
+@Collector
+class PurgeMongoDB():
+    """Class: PurgeMongoDB
+    Purpose of this class is to purge physical data locations outside of Rucio which are registered to
+    a meta database.
+
+    Due to the complex file structure our data products the purge command became quite extensive in terms of
+    selections to narrow down the datasets (depending on type, version (hash), host and location).
+
+    PurgeMongoDB runs a purging process only one type of data (e.g. raw_records) at the same time. Multiple types
+    are not supported (yet?).
+
+    Therefore you can run this command with these inputs:
+
+    admix PurgeMongoDB --admix-config /path/to/config/file.config
+                       --select-run-times <date>_<time> (as single, multi or range)
+                          or
+                       --select-run-number XXXXX (as single or range)
+                       --type data_type (e.g. raw_records)
+                       --hash XXXXXXXXXX (10 character hash sum which represents a certain version of the data type
+                       --force (Allows you enforce manual purge mode)
+    Full example:
+    admix PurgeMongoDB --once --admix-config  /home/bauermeister/Development/software/admix_config/host_config_dali_olddb.config --select-run-times 171225_0040-171225_0140 --type raw_records records --hash 7k65yaooed --force
+
+    """
+    def __init__(self):
+        pass
+
+    def init(self):
+        helper.global_dictionary['logger'].Info(f'Init task {self.__class__.__name__}')
+
+        # Init the runDB
+        self.db = ConnectMongoDB()
+        self.db.Connect()
+
+        # We want the first and the last run:
+        self.gboundary = self.db.GetBoundary()
+        self.run_nb_min = self.gboundary['min_number']
+        self.run_nb_max = self.gboundary['max_number']
+        self.run_ts_min = self.gboundary['min_start_time']
+        self.run_ts_max = self.gboundary['max_start_time']
+
+        # Init the Rucio data format evaluator in three steps:
+        self.rc_reader = ConfigRucioDataFormat()
+        self.rc_reader.Config(helper.get_hostconfig('rucio_template'))
+
+        # This class will evaluate your destinations:
+        self.destination = Destination()
+
+        # Since we deal with an experiment, everything is predefine:
+        self.exp_temp = Templater()
+        self.exp_temp.Config(helper.get_hostconfig()['template'])
+
+        # Init a class to handle keyword strings:
+        self.keyw = Keyword()
+
+        # Init Rucio for later uploads and handling:
+        self.rc = RucioSummoner(helper.get_hostconfig("rucio_backend"))
+        self.rc.SetRucioAccount(helper.get_hostconfig('rucio_account'))
+        self.rc.SetConfigPath(helper.get_hostconfig("rucio_cli"))
+        self.rc.SetProxyTicket(helper.get_hostconfig('rucio_x509'))
+        self.rc.SetHost(helper.get_hostconfig('host'))
+        self.rc.ConfigHost()
+
+    def run(self, *args, **kwargs):
+        helper.global_dictionary['logger'].Info(f'Run task {self.__class__.__name__}')
+
+        # Check for type pre-selection
+        d_type = None
+        d_hash = None
+        if helper.global_dictionary.get("type") is None:
+            helper.global_dictionary['logger'].Info(
+                'Selected type of data to purge: {0}'.format(helper.global_dictionary.get("type")))
+            helper.global_dictionary['logger'].Info("No data type is selected! Nothing to purge -> Finish here")
+            return 1
+        else:
+            d_type = helper.global_dictionary.get("type")[0]
+
+        if helper.global_dictionary.get("hash") is None:
+            helper.global_dictionary['logger'].Info(
+                'Selected type of data to purge: {0}'.format(helper.global_dictionary.get("hash")))
+            helper.global_dictionary['logger'].Info(
+                "No data hash (version) is selected! Nothing to purge -> Finish here")
+            return 1
+        else:
+            d_hash = helper.global_dictionary.get("hash")[0]
+
+        ts_beg = None
+        ts_end = None
+        if helper.global_dictionary.get('run_numbers') != None:
+            # Evaluate terminal input for run number assumption (terminal input == true)
+            true_nb_beg, true_nb_end = helper.eval_run_numbers(helper.global_dictionary.get('run_numbers'),
+                                                               self.run_nb_min,
+                                                               self.run_nb_max)
+            # Get the timestamps from the run numbers:
+            ts_beg = self.db.FindTimeStamp('number', int(true_nb_beg))
+            ts_end = self.db.FindTimeStamp('number', int(true_nb_end))
+
+        elif helper.global_dictionary.get('run_timestamps') != None:
+            # Evaluate terminal input for run name assumption
+            true_ts_beg, true_ts_end = helper.eval_run_timestamps(helper.global_dictionary.get('run_timestamps'),
+                                                                  self.run_ts_min,
+                                                                  self.run_ts_max)
+            ts_beg = true_ts_beg
+            ts_end = true_ts_end
+
+        elif helper.global_dictionary.get('run_timestamps') == None and \
+            helper.global_dictionary.get('run_numbers') == None:
+            ts_beg = self.run_ts_min
+            ts_end = self.run_ts_max
+        else:
+            helper.global_dictionary['logger'].Error(
+                "Check for your input arguments (--select-run-number or --select-run-time")
+            exit(1)
+            # exection
+
+        # After we know the times:
+        helper.global_dictionary['logger'].Info(f"Run between {ts_beg} and {ts_end}")
+
+        print("Purge Module")
+        host_name = helper.get_hostname()
+        hc_host = helper.get_hostconfig("host")  # Supposed to be the database entry to identfy locations
+
+        # Get your collection of run numbers and run names what contain a certain host of choice
+        # hint: You are allowed to get several plugins (types) and versions (hashsums) for the same
+        #       dataset at a certain host.
+        collection = self.db.GetHosts(hc_host, ts_beg, ts_end)
+
+        # Run through the overview collection:
+        for i_run in collection:
+
+            # Extract run number and name from overview collection
+            r_name = i_run['name']
+            r_number = i_run['number']
+
+            # Pull the full run information (according to projection which is pre-defined) by the run name
+            db_info = self.db.GetRunByName(r_name)[0]
+
+            print(db_info['name'], db_info['number'])
+
+            # Data are supposed to have enough rucio copies:
+            valid_rucio_copies = 0
+            valid_rucio_rses = ""
+            for i_data in db_info['data']:
+                if i_data['host'] != "rucio-catalogue":
+                    continue
+                if i_data['type'] != d_type:
+                    continue
+                if d_hash not in i_data['location']:
+                    continue
+                if i_data['status'] != 'transferred':
+                    continue
+                valid_rucio_copies = sum([1 if i_rse.split(":")[1] == 'OK' else 0 for i_rse in i_data['rse']])
+                valid_rucio_rses = [i_rse.split(":")[0] if i_rse.split(":")[1] == 'OK' else '' for i_rse in i_data['rse']]
+            valid_rucio_rses = ', '.join(list(filter(None, valid_rucio_rses)))
+
+
+            valid_disk_copies = 0
+            for i_data in db_info['data']:
+                if i_data['host'] == "rucio-catalogue":
+                    continue
+                if i_data['host'] == hc_host:
+                    continue
+                if i_data['type'] != d_type:
+                    continue
+                if d_hash not in i_data['location']:
+                    continue
+                if i_data['status'] != 'transferred':
+                    continue
+                valid_disk_copies += 1
+
+
+            #Determine what to purge
+            path_to_purge = None
+            pHost = None
+            pType = None
+            pDict = None
+            for i_data in db_info['data']:
+                if i_data['host'] != hc_host:
+                    continue
+                if i_data['type'] != d_type:
+                    continue
+                if d_hash not in i_data['location']:
+                    continue
+                path_to_purge = i_data['location']
+                pHost = i_data['host']
+                pType = i_data['type']
+                pDict = i_data
+            #purge without request is ok if:
+            # - two valid rucio copies ("OK" for transfer)
+            # - one valid rucio copy and one or more valid disk copies
+            if ((valid_rucio_copies >= 2) or (valid_rucio_copies == 1 and valid_disk_copies >= 1)) and \
+                ( helper.global_dictionary.get("force") == False):
+
+                helper.global_dictionary['logger'].Info("Prepare to purge data path:")
+                helper.global_dictionary['logger'].Info(f"> {path_to_purge}")
+
+                #purge disk location
+                purge_test = False
+                try:
+                    shutil.rmtree(path_to_purge)
+                    helper.global_dictionary['logger'].Info("> Removed from disk [finished]")
+                    purge_test = True
+                except IOError as e:
+                    helper.global_dictionary['logger'].Error("Unable to purge physical file")
+
+                if purge_test == True:
+                    #de-register from database
+                    self.db.RemoveDatafield(db_info['_id'], pDict)
+                    helper.global_dictionary['logger'].Info("> Removed from runDB [finished]")
+
+            elif helper.global_dictionary.get("force") == True:
+                helper.global_dictionary['logger'].Info("WARNING! You activated --force")
+                helper.global_dictionary['logger'].Info("Confirm purge of datasets manually!")
+                helper.global_dictionary['logger'].Info(f"Location: {path_to_purge}")
+                helper.global_dictionary['logger'].Info(f"Type: {pType}")
+                helper.global_dictionary['logger'].Info(f"Host: {pHost}")
+                helper.global_dictionary['logger'].Info(f"Copies on other disks then {hc_host}: {valid_disk_copies}")
+                helper.global_dictionary['logger'].Info(f"Copies in Rucio: {valid_rucio_copies}: {valid_rucio_rses}")
+
+                f_purge = input("Do you with to purge that location (type in yes/no)? ")
+                if f_purge == 'yes':
+                    # purge disk location
+                    purge_test = False
+                    try:
+                        shutil.rmtree(path_to_purge)
+                        helper.global_dictionary['logger'].Info("> Removed from disk [finished]")
+                        purge_test = True
+                    except IOError as e:
+                        helper.global_dictionary['logger'].Error("Unable to purge physical file")
+
+                    if purge_test == True:
+                        # de-register from database
+                        self.db.RemoveDatafield(db_info['_id'], pDict)
+                        helper.global_dictionary['logger'].Info("> Removed from runDB [finished]")
+
+                else:
+                    helper.global_dictionary['logger'].Info("You have choosen to not purge data")
+
+            else:
+                helper.global_dictionary['logger'].Info("Purging data is rejected!")
+
+
+
+        return 0

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -16,22 +16,22 @@ Run aDMIX to upload data sets (e.g. XENONnT plugins) into Rucio.
 Basic command outline:
 
 .. code-block:: console
-    
+
     admix UploadMongoDB --admix-config <CONFIG-FILE>
 
 Further comand arguments are:
   - '--once':
     Run the command only once and exit aDMIX
-  
-  - '--select-run-numbers': 
+
+  - '--select-run-numbers':
     Select run numbers according the following scheme. The run number is defined by the MongoDB entry with the field 'number'. Hint: The Separator is '-'. Do not use spaces in between.
-    
+
       * 00001: Only one run with run number
       * 00001-00002: All run numbers between 1 and (including) 2
-  
-  - '--select-run-times': 
-    Select run times according to the start times of a run. The run time is defined by the MongoDB entry with the field 'start'. A correct definition of the run time is "<Date>_<Time>-<Date>_<Time>". No single time stamps are allowed. Separators are '_' between <Date> and <Time> and '-' between two timestamps.                       
-                          
+
+  - '--select-run-times':
+    Select run times according to the start times of a run. The run time is defined by the MongoDB entry with the field 'start'. A correct definition of the run time is "<Date>_<Time>-<Date>_<Time>". No single time stamps are allowed. Separators are '_' between <Date> and <Time> and '-' between two timestamps.
+
 You can run the aDMIX upload command from any machine where the data are located. The database needs to hold a list of dictionaries and each dictionary presents a data type with location, status, rse (if Rucio) and destinations. An overview example could be:
 
 .. _table1:
@@ -56,7 +56,7 @@ You can run the aDMIX upload command from any machine where the data are located
 | midway-login1   | /project/lgrandi/xenon1t/processed/pax_v | transferred  | None                           | None                           |
 |                 | 6.10.1/170319_1211.root                  |              |                                |                                |
 +-----------------+------------------------------------------+--------------+--------------------------------+--------------------------------+
-| dali            | /dali/lgrandi/tunnell/strax_data/170319  | transferred  | None                           | ['rucio-catalogue:UC_OSG_USER  |                            
+| dali            | /dali/lgrandi/tunnell/strax_data/170319  | transferred  | None                           | ['rucio-catalogue:UC_OSG_USER  |
 |                 | _1211-records-943c2b3857b2a91358355745245|              |                                |  DISK:None']                   |
 |                 | 1b5049362ecbd                            |              |                                |                                |
 +-----------------+------------------------------------------+--------------+--------------------------------+--------------------------------+
@@ -64,7 +64,7 @@ You can run the aDMIX upload command from any machine where the data are located
 The location must be definied according to the definition in the *template.config* configuration file. An example for an inidivdual plugin looks like:
 
 .. code-block:: json
-    
+
     {
     "raw_records":{
         "login":"{abs_path}/{number}-{plugin}-{hash}",
@@ -77,8 +77,8 @@ The location must be definied according to the definition in the *template.confi
         "login":"{abs_path}/{number}-{plugin}-{hash}",
         },
     }
-    
-    
+
+
 The keywords such as abs_path, number,... are detemined by aDMIX automatically. The abs_path is detemined from the location where the data are stored at a certain location.
 
 The aDMIX uploader runs continously on the pre-selected run numbers or time stamps and looks for *destinations* which are set for **the same host** whereas aDMIX is running. The destination field is detemined by the destination (rucio-catalogue), the Rucio RSE and a possible lifetime for this upload. You can set several Rucio RSE destinations (strings which are separated by komma) but the first element of the list is the RSE where the data are uploaded the first time.
@@ -94,28 +94,28 @@ Run aDMIX to upload data sets (e.g. XENONnT plugins) into Rucio.
 Basic command outline:
 
 .. code-block:: console
-    
+
     admix UpdateRunDBMongoDB --admix-config <CONFIG-FILE>
 
 Further comand arguments are:
   - '--once':
     Run the command only once and exit aDMIX
-  
-  - '--select-run-numbers': 
+
+  - '--select-run-numbers':
     Select run numbers according the following scheme. The run number is defined by the MongoDB entry with the field 'number'. Hint: The Separator is '-'. Do not use spaces in between.
-    
+
       * 00001: Only one run with run number
       * 00001-00002: All run numbers between 1 and (including) 2
-  
-  - '--select-run-times': 
-    Select run times according to the start times of a run. The run time is defined by the MongoDB entry with the field 'start'. A correct definition of the run time is "<Date>_<Time>-<Date>_<Time>". No single time stamps are allowed. Separators are '_' between <Date> and <Time> and '-' between two timestamps. 
 
-    
+  - '--select-run-times':
+    Select run times according to the start times of a run. The run time is defined by the MongoDB entry with the field 'start'. A correct definition of the run time is "<Date>_<Time>-<Date>_<Time>". No single time stamps are allowed. Separators are '_' between <Date> and <Time> and '-' between two timestamps.
+
+
 Since several transfers within the Rucio catalogue are ongoing (see :_table1: for plugin 'raw' in column rse) we need to update the experiment database from time to time with the latest locations from Rucio. Run this command continously on *any location* with an installed Rucio catalogue.
 
 **Attention:** Due to deletion processes for Rucio transfer rules in the Rucio catalogue it might be possible that a certain dataset *does not* have any Rucio transfer rule. In this situation, the command set the status of the according Rucio database entry (rucio-catalogue) to *RucioClearance*. This status acts a as a pre-stage to remove the whole rucio-catalogue entry for the given plugin type from the database with the *ClearTransfersMongoDB* option.
-    
-    
+
+
 Init Rucio Transfers (with MongoDB)
 -----------------------------------
 
@@ -125,21 +125,21 @@ Run aDMIX to upload data sets (e.g. XENONnT plugins) into Rucio.
 Basic command outline:
 
 .. code-block:: console
-    
+
     admix InitTransfersMongoDB --admix-config <CONFIG-FILE>
 
 Further comand arguments are:
   - '--once':
     Run the command only once and exit aDMIX
-  
-  - '--select-run-numbers': 
+
+  - '--select-run-numbers':
     Select run numbers according the following scheme. The run number is defined by the MongoDB entry with the field 'number'. Hint: The Separator is '-'. Do not use spaces in between.
-    
+
       * 00001: Only one run with run number
       * 00001-00002: All run numbers between 1 and (including) 2
-  
-  - '--select-run-times': 
-    Select run times according to the start times of a run. The run time is defined by the MongoDB entry with the field 'start'. A correct definition of the run time is "<Date>_<Time>-<Date>_<Time>". No single time stamps are allowed. Separators are '_' between <Date> and <Time> and '-' between two timestamps. 
+
+  - '--select-run-times':
+    Select run times according to the start times of a run. The run time is defined by the MongoDB entry with the field 'start'. A correct definition of the run time is "<Date>_<Time>-<Date>_<Time>". No single time stamps are allowed. Separators are '_' between <Date> and <Time> and '-' between two timestamps.
 
 aDMIX is able to fetch *new* destinations for a given rucio-catalogue entry and plugin type. These destinations are defined similar to upload destinations. It is a list of strings:
 
@@ -147,46 +147,89 @@ aDMIX is able to fetch *new* destinations for a given rucio-catalogue entry and 
 
     destination = ['rucio-catalogue:UC_DALI_USERDISK:None',
                    'rucio-catalogue:NIKHEF_USERDISK:86400']
-                   
+
 You can set up the database entries from any location and run the aDMIX instance from any location with a pre-installed Rucio software package. aDMIX will fullfill all demanded destinations for the Rucio transfer rules.
 
 **Attention**
   * Each rule can be initialized with a lifetime (third argument). This lifetime is given in seconds (always). You are able to extend the lifetime at any point as long as there is a rule existing in the Rucio catalogue.
   * You can use the lifetime to **purge** data from the Rucio catalogue. If the lifetime is set to 10 seconds, Rucio will remove the transfer rule after 10 seconds automatically and the Rucio services in the background will start to purge data from the according RSE. Be aware that Rucio services crash sometimes in the background. If data do not disappear automatically you need to check manually for it.
-    
+
 Clear Rucio Information from Run Database (with MongoDB)
 --------------------------------------------------------
-
-Run aDMIX to upload data sets (e.g. XENONnT plugins) into Rucio.
-
 
 Basic command outline:
 
 .. code-block:: console
-    
+
     admix ClearTransfersMongoDB --admix-config <CONFIG-FILE>
 
 Further comand arguments are:
   - '--once':
     Run the command only once and exit aDMIX
-  
-  - '--select-run-numbers': 
+
+  - '--select-run-numbers':
     Select run numbers according the following scheme. The run number is defined by the MongoDB entry with the field 'number'. Hint: The Separator is '-'. Do not use spaces in between.
-    
+
       * 00001: Only one run with run number
       * 00001-00002: All run numbers between 1 and (including) 2
-  
-  - '--select-run-times': 
-    Select run times according to the start times of a run. The run time is defined by the MongoDB entry with the field 'start'. A correct definition of the run time is "<Date>_<Time>-<Date>_<Time>". No single time stamps are allowed. Separators are '_' between <Date> and <Time> and '-' between two timestamps. 
+
+  - '--select-run-times':
+    Select run times according to the start times of a run. The run time is defined by the MongoDB entry with the field 'start'. A correct definition of the run time is "<Date>_<Time>-<Date>_<Time>". No single time stamps are allowed. Separators are '_' between <Date> and <Time> and '-' between two timestamps.
 
 
 This command clears the database entries for the host rucio-catalogue when the status is set to *RucioClearance*. You can do this manually or it is set to *RucioClearance* by the UpdateRunDBMongoDB command of aDMIX. You can run this command from any location.
 
 **Attention**
   * No cross check for the number of locations! Keep this in mind in case you fear Rucio-database issues. Run a manual cross check before to avoid data loss from the database.
-    
-    
-    
+
+Purge Physical Data Locations on Disks (with MongoDB)
+-----------------------------------------------------
+This module allows you to purge data from physical data disks in a safe way. As an outcome, the physical disk location
+are de-registered from the meta database.
+
+You can run this command only at locations where do you intend to purge data. In that sense it becomes also important to
+specify host location in your configuration file to avoid uncertain host conditions.
+
+This command requests by default a two fold data existence before purging data from a physical disk. This assures that
+no datasets are deleted at the Rucio entry point before there are enough copies of the data spread. The two fold
+requirement is defined as:
+
+  - Two copies in Rucio which are in replication status OK and marked in the meta database with "transferred"
+  - One copy in Rucio with replication status OK and marked in meta database with "transferred". In addition one ore more
+    disk copies at several sites. Disk locations are determined by database only.
+
+The '--force' command can be used to enable a manual mode to purge data on disks which do not fulfil the minimum data
+safety requirement. Each dataset must be confirmed with 'yes'.
+
+Basic command outline:
+
+.. code-block:: console
+
+    admix PurgeMongoDB --admix-config <CONFIG-FILE>
+
+Due to the complex file structure our data products the purge command became quite extensive in terms of
+selections to narrow down the datasets (depending on type, version (hash), host and location). The supported
+terminal arguments are:
+
+  - '--once':
+    Run the command only once and exit aDMIX
+  - '--select-run-numbers':
+    Select run numbers according the following scheme. The run number is defined by the MongoDB entry with the field 'number'. Hint: The Separator is '-'. Do not use spaces in between.
+
+      * 00001: Only one run with run number
+      * 00001-00002: All run numbers between 1 and (including) 2
+  - '--select-run-times':
+    Select run times according to the start times of a run. The run time is defined by the MongoDB entry with the field 'start'. A correct definition of the run time is "<Date>_<Time>-<Date>_<Time>". No single time stamps are allowed. Separators are '_' between <Date> and <Time> and '-' between two timestamps.
+  - '--type':
+    Define a specific data product for purging (e.g. raw_records). The input allows multiple arguments but that specific
+    application (PurgeMongoDB) makes only use of one argument at one time.
+  - '--hash':
+    The hash sum is part of the data location and refers to a specific version of the chosen data product type. Choose
+    the hash from the meta database in advance.
+  - '--force':
+    Enforces a user to purge datasets which are prevented from purging. (Not enough copies in Rucio or other disks)
+
+
 aDMIX as a Module
 +++++++++++++++++
 
@@ -214,7 +257,7 @@ A Rucio template dictionary is defined in aDMIX as a dictionary with the followi
             "tag_words": ["date", "time", "detector", "plugin", "hash"],
             }
     }
-    
+
 
 aDMIX is shipped out with two modules which help you create this structure: *templater* and *keyword*. The aim of the *templater* module is to load a specific Rucio data structure from a configuration file. This helps you to provide several Rucio configurations for different experimental setups and allow you create automatically a complex Rucio structure, such as a dataset which is attached to container.
 
@@ -237,36 +280,36 @@ For example we have:
   - $Cx1t_SR{science_run}:xe1t_SR{science_run}_data: It defines by default a Rucio container (introduced by $C at the begin of the string).
   - Another container ($Cx1t_SR{science_run}:x1t_SR{science_run}_{date}_{time}_{detector}) is attached to the top level container $Cx1t_SR{science_run}:xe1t_SR{science_run}_data. This is introduced by the arrow feature ("|->|").
   - Finally we have another Rucio dataset attached ($Dx1t_SR{science_run}_{date}_{time}_{detector}:raw). A Rucio dataset is introduced by "$D" at the begin.
-  
+
 Have in mind that each level is defined by a Rucio data identifier which consist of a scope and name (scope:name) which are separated by a ':' character. The lowest structure (Rucio dataset) will receive the files during the upload process later). Each Rucio structure template contains keywords which ({date} or {science_run}). We are going to fill these keywords later by the *keyword* method:
 
 A full code example for XENONnT is given here:
 
 .. code-block:: python
-    
+
     from admix.interfaces.rucio_dataformat import ConfigRucioDataFormat
     from admix.interfaces.keyword import Keyword
     from admix.interfaces.templater import Templater
-    
+
     #Init the method to load a specific Rucio template configuration file:
-    
+
     path_to_your_rucio_configuration_file = "/.../.."
-    
+
     rc_reader = ConfigRucioDataFormat()
     rc_reader.Config(path_to_your_rucio_configuration_file)
-    
+
     #Receive the empty plugin structure from the configuration file:
     plugin_type = "raw_records"
     rucio_template = rc_reader.GetPlugin(plugin_type)
-    
-    
+
+
     #Init the keyword method
     keyw = Keyword()
-    
+
     #Prepare the keyword method to fill the keywords from the template:
-    
+
     rucio_in = "x1t_SR001_170319_1011_tpc:raw_records-58340a130"
-        
+
     db = {}
     db['plugin']   = rucio_in.split(":")[1].split("-")[0]
     db['date']     = rucio_in.split(":")[0].split("_")[2]
@@ -274,13 +317,13 @@ A full code example for XENONnT is given here:
     db['detector'] = rucio_in.split(":")[0].split("_")[4]
     db['hash']     = rucio_in.split(":")[1].split("-")[1]
     db['science_run'] = rucio_in.split(":")[0].split("_")[1].replace("SR", "")
-    
+
     keyw.SetTemplate(db)
     #(we assume here that the dictionary db is filed from a string. But it can come from any location (e.g. database, textfile)!
-    
+
     #Complete the Rucio template:
     rucio_template = keyw.CompleteTemplate(rucio_template)
-    
+
 
 The variable rucio_template holds the desired complex Rucio structure for a given plugin type.
 
@@ -314,7 +357,7 @@ How to download a given Rucio DID which is defined as "x1t_SR001_171230_1818_tpc
 
     #Most likely you are getting the run locations for a type
     did = "x1t_SR001_171230_1818_tpc:raw_records-7k65yaooed"
-    
+
     #Extract scope and name:
     scope = did.split(":")[0]
     dname = did.split(":")[1]
@@ -324,10 +367,10 @@ How to download a given Rucio DID which is defined as "x1t_SR001_171230_1818_tpc
                          rse="YOUR_DOWNLOAD_RSE",
                          no_subdir=False #if true, the DID name is not used in the download path
                          )
-    
+
     print(result)
-   
-    
+
+
 
 Download Single Chunks from a Rucio Data Identifier (DID)
 ---------------------------------------------------------
@@ -361,11 +404,11 @@ Let's assume the three chunks are '00001', '00002' and '00003'. Based on the gen
 
     #Most likely you are getting the run locations for a type
     did = "x1t_SR001_171230_1818_tpc:raw_records-7k65yaooed"
-    
+
     #Extract scope and name:
     scope = did.split(":")[0]
     dname = did.split(":")[1]
-    
+
     #Create a list of three chunks:
     chunks = [ str(i).zfill(6) for i in range(0, 3)]
     download_path = "/your/download/path/"
@@ -377,25 +420,25 @@ Let's assume the three chunks are '00001', '00002' and '00003'. Based on the gen
                                download_path=download_path,
                                rse=rse,
                                no_subdir=no_subdir)
-    
+
     #result is a list of dictionaries:
     for i_result i result:
         print(i_result)
 
-        
+
 Download from Rucio with a Template Dictionary (with chunks)
 ------------------------------------------------------------
 In additon to the Rucio downloads with a DID, aDMIX supports a Rucio template dictionary download too. It is important to notice that by default only the lowest level Rucio dataset is downloaded. It is possible to adjust it by specifing the level manually when calling the Download(...) function of aDMIX. Be aware that due to a complex Rucio structure, the download volume can be increased tremendously.
- 
+
 .. code-block:: python
-    
+
     #imports:
     from admix.interfaces.rucio_dataformat import ConfigRucioDataFormat
     from admix.interfaces.rucio_summoner import RucioSummoner
     from admix.interfaces.destination import Destination
     from admix.interfaces.keyword import Keyword
     from admix.interfaces.templater import Templater
-    
+
     #Be aware of the template files and the config "fake" setup":
     config_file = "/home/bauermeister/Development/software/admix_config/host_config_login_el7_api.config"
 
@@ -410,12 +453,12 @@ In additon to the Rucio downloads with a DID, aDMIX supports a Rucio template di
     rc.SetHost(config.get('host'))
     rc.ConfigHost()
 
-    
+
     ...CODE TO CREATE/LOAD/USE A RUCIO TEMPLATE DICTIONARY...
 
     rucio_template = keyw.CompleteTemplate(rucio_template)
 
-    
+
     result = rc.Download(download_structure=rucio_template,
                          download_path="/your/download/path/",
                          rse="YOUR_DOWNLOAD_RSE",
@@ -427,7 +470,7 @@ In additon to the Rucio downloads with a DID, aDMIX supports a Rucio template di
 In addition, it is possible to modify the Download command for chunks again:
 
 .. code-block:: python
-    
+
     chunks = [ str(i).zfill(6) for i in range(0, 3)]
     result = rc.DownloadChunks(download_structure=rucio_template,
                                chunks=chunks,
@@ -465,15 +508,14 @@ Of course you can also use UploadToDid(...) or UploadToScope(...) from the Rucio
     rc.SetProxyTicket(config.get('rucio_x509'))
     rc.SetHost(config.get('host'))
     rc.ConfigHost()
-    
+
     #prepare a rucio_template as described above:
     rucio_template = ...
-    
-    
+
+
     upload_result = self.rc.Upload(upload_structure=rucio_template,
                                    upload_path=origin_location, #A valid path with data to upload
                                    rse="INITIAL_RSE_UPLOAD",
-                                   rse_lifetime=None, #Or lifetime in seconds 
+                                   rse_lifetime=None, #Or lifetime in seconds
                                    )
     print(upload_result) # 0 if successful, 1 if failed
-    


### PR DESCRIPTION
Another missing piece is a function in aDMIX which allows to purge physical disk locations (non-Rucio). This becomes important for data locations at the Rucio entry point (DAQ site). That new function allows to purge data based on a two fold data safety:
  * Two valid Rucio copies
  * One valid Rucio copy + another physical disk storage (determined by database entry)
