### PR TITLE
Eb delete

### DIFF
--- a/admix/admix.py
+++ b/admix/admix.py
@@ -19,6 +19,10 @@ from admix.tasks.purge_with_mongodb import PurgeMongoDB
 from admix.tasks.upload_from_lngs import UploadFromLNGS
 from admix.tasks.fix_upload import FixUpload
 from admix.tasks.clean_eb import CleanEB
+from admix.tasks.upload_from_lngs_single_thread import UploadFromLNGSSingleThread
+from admix.tasks.check_transfers import CheckTransfers
+from admix.tasks.move_data_to_rse import MoveDataToRSE
+from admix.tasks.monitor_run import MonitorRun
 from utilix.config import Config
 
 def version():
@@ -64,13 +68,15 @@ def your_admix():
                         help="Select your RSE from where to download data")
     parser.add_argument('--force', default=False, action="store_true",
                         help="Enforce your action. Be aware of the application!")
+    parser.add_argument('--sleep-time', dest='sleep_time', type=int,
+                        help="Time to wait before running again the task")
     args = parser.parse_args()
 
     #We make the individual arguments global available right after aDMIX starts:
     if args.select_run_numbers != None and args.select_run_times == None:
         helper.make_global("run_numbers", args.select_run_numbers)
     if args.select_run_times != None and args.select_run_numbers == None:
-        helper.make_global("run_timestamps", args.select_run_times)
+        helper.make_global("run_timestamps", args.select_run_times)        
 
     helper.make_global("admix_config", os.path.abspath(args.admix_config))
     helper.make_global("no_db_update", args.no_update)
@@ -79,6 +85,11 @@ def your_admix():
     helper.make_global("type", args.type)
     helper.make_global("hash", args.hash)
     helper.make_global("force", args.force)
+
+    if args.sleep_time != None:
+        helper.make_global("sleep_time", args.sleep_time)
+    else:
+        helper.make_global("sleep_time",helper.get_hostconfig()['sleep_time'])
 
     #Pre tests:
     # admix host configuration must match the hostname:
@@ -122,9 +133,6 @@ def your_admix():
     for i_task in task_list:
         ClassCollector[i_task].init()
 
-    #Gets the sleep time for loops
-    sleep_time = helper.get_hostconfig()['sleep_time']
-
     #Go for the loop
     while True:
 
@@ -135,5 +143,11 @@ def your_admix():
         if args.once == True:
             break
 
-        helper.global_dictionary['logger'].Info('Waiting for {0} seconds'.format(sleep_time))
-        time.sleep(sleep_time)
+        print('Waiting for {0} seconds'.format(helper.global_dictionary['sleep_time']))
+        print("You can safely CTRL-C now if you need to stop me")
+        try:
+            time.sleep(helper.global_dictionary['sleep_time'])
+        except KeyboardInterrupt:
+            break
+
+

--- a/admix/admix.py
+++ b/admix/admix.py
@@ -18,6 +18,7 @@ from admix.tasks.clear_transfers_with_mongdb import ClearTransfersMongoDB
 from admix.tasks.purge_with_mongodb import PurgeMongoDB
 from admix.tasks.upload_from_lngs import UploadFromLNGS
 from admix.tasks.fix_upload import FixUpload
+from admix.tasks.clean_eb import CleanEB
 from utilix.config import Config
 
 def version():

--- a/admix/config/datamanager.config
+++ b/admix/config/datamanager.config
@@ -4,6 +4,7 @@
     "log_path": "/home/datamanager/logs/admix.log",
     "type": ["raw_records", "records", "peaks"], 
     "rawtype": ["raw_records", "raw_records_he", "raw_records_aqmon", "raw_records_mv","pulse_counts", "veto_regions", "records", "lone_hits", "peaklets"],
+    "rses": ["LNGS_USERDISK","UC_OSG_USERDISK", "UC_DALI_USERDISK","CNAF_TAPE2_USERDISK","CNAF_USERDISK","NIKHEF2_USERDISK","CCIN2P3_USERDISK"],
     "path_data_to_upload": "/eb/ebdata",
     "detector": ["tpc"],
     "source": [], 

--- a/admix/config/datamanager.config
+++ b/admix/config/datamanager.config
@@ -4,7 +4,11 @@
     "log_path": "/home/datamanager/logs/admix.log",
     "type": ["raw_records", "records", "peaks"], 
     "rawtype": ["raw_records", "raw_records_he", "raw_records_aqmon", "raw_records_mv","pulse_counts", "veto_regions", "records", "lone_hits", "peaklets"],
+    "norecords_types": ["pulse_counts", "veto_regions", "lone_hits", "peaklets","merged_s2s","peak_basics","peaklet_classification"],
+    "raw_records_types": ["raw_records", "raw_records_he", "raw_records_aqmon", "raw_records_mv"],
+    "records_types": ["records"],
     "rses": ["LNGS_USERDISK","UC_OSG_USERDISK", "UC_DALI_USERDISK","CNAF_TAPE2_USERDISK","CNAF_USERDISK","NIKHEF2_USERDISK","CCIN2P3_USERDISK"],
+    "upload_to": "LNGS_USERDISK",
     "path_data_to_upload": "/eb/ebdata",
     "detector": ["tpc"],
     "source": [], 
@@ -28,7 +32,7 @@
                                    "start":true
                     }
                 },
-    "sleep_time": 60,
+    "sleep_time": 10,
     "upload_periodic_check": 300,
     "experiment": "XENONnT"
 }

--- a/admix/helper/logger.py
+++ b/admix/helper/logger.py
@@ -29,7 +29,7 @@ class Logger():
         self._loghandler.setLevel(logging.DEBUG)
         # create file handler which logs even debug messages
         fh = logging.FileHandler(self.logpath)
-        fh.setLevel(logging.INFO)
+        fh.setLevel(logging.DEBUG)
         # create console handler with a higher log level
         ch = logging.StreamHandler()
         ch.setLevel(logging.DEBUG)

--- a/admix/interfaces/rucio_api.py
+++ b/admix/interfaces/rucio_api.py
@@ -10,6 +10,7 @@
 import os
 from rucio.client.client import Client
 from rucio.client.uploadclient import UploadClient
+#from admix.interfaces.uploadclient import UploadClient
 from rucio.client.downloadclient import DownloadClient
 from rucio.common.exception import DataIdentifierAlreadyExists
 from rucio.common.exception import AccountNotFound
@@ -101,6 +102,8 @@ class RucioAPI():
         try:
             self._rucio_client = Client()
             self._rucio_client_upload = UploadClient()
+#            self._rucio_client_upload = UploadClient(tracing=False)
+#            print("Tracing set to False")
             self._rucio_client_download = DownloadClient()
             self._rucio_ping = self._rucio_client.ping
 

--- a/admix/interfaces/rucio_summoner.py
+++ b/admix/interfaces/rucio_summoner.py
@@ -206,6 +206,42 @@ class RucioSummoner():
                              lifetime=lifetime)
         return 0
 
+
+    def AddConditionalRule(self, did, from_rse, to_rse, lifetime=None, protocol='rucio-catalogue'):
+        """Add rules for a Rucio DID or dictionary template.
+
+        :param: did: Rucio DID form of "scope:name"
+        :param: rse: An existing Rucio storage element (RSE)
+        :param: lifetime: Choose a lifetime of the transfer rule in seconds or None
+        :param: protocol: Should always be 'rucio-catalogue'?
+        :return:
+        """
+
+        # analyse the function input regarding its allowed definitions:
+        val_scope, val_dname = self._VerifyStructure(did)
+
+        # Get current rules for this did
+        rules = self._rucio.ListDidRules(val_scope, val_dname)
+        current_rses = [r['rse_expression'] for r in rules]
+
+        # if a rule already exists, exit
+        if to_rse in current_rses:
+            print("There already exists a rule for DID %s at RSE %s" % (did, to_rse))
+            return 1
+
+        # add rule
+        did_dict= {}
+        did_dict['scope'] = val_scope
+        did_dict['name']  = val_dname
+
+        self._rucio.AddRule( [did_dict],
+                             copies=1,
+                             rse_expression=to_rse,
+                             source_replica_expression=from_rse,
+                             lifetime=lifetime)
+        return 0
+
+
     def UpdateRules(self, upload_structure=None, rse_rules=None, level=-1):
         """Update existing rules for a Rucio DID or dictionary template.
 

--- a/admix/showrun.py
+++ b/admix/showrun.py
@@ -8,7 +8,7 @@ from admix.utils.naming import make_did
 from admix.utils.list_file_replicas import list_file_replicas
 
 
-def showrun(number, dtype, hash, rse):
+def showrun(number, dtype, hash, rse='UC_DALI_USERDISK'):
     """Function showrun()
     
     Show the full path of a given run number using rucio
@@ -21,7 +21,7 @@ def showrun(number, dtype, hash, rse):
 #    rc = RucioSummoner()
     db = ConnectMongoDB()
     
-    files = list_file_replicas(number, dtype, hash)
+    files = list_file_replicas(number, dtype, hash, rse)
 #    files = list_file_replicas(number, dtype, hash,'UC_DALI_USERDISK')
 
     print(files)

--- a/admix/tasks/check_transfers.py
+++ b/admix/tasks/check_transfers.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+import json
+import os
+from admix.helper import helper
+import time
+import shutil
+
+from admix.interfaces.database import ConnectMongoDB
+from admix.helper.decorator import Collector
+
+#get Rucio imports done:
+from admix.interfaces.rucio_dataformat import ConfigRucioDataFormat
+from admix.interfaces.rucio_summoner import RucioSummoner
+from admix.utils import make_did
+
+@Collector
+class CheckTransfers():
+    """
+    Using the runDB, it searches for all runs and all data types for which a Rucio rule is ongoing
+    (identified by both status specific data.status equal to "transferring".
+    For each of them, it checks, by using Rucio API commands, if those rules have been
+    succesfully completed. If so, the corresponding data.status is updated as
+    "transferred". If all data types are flagged as transferred, then the run itself
+    is flagged as "transferred".
+    """
+
+    def __init__(self):
+        pass
+
+    def init(self):
+        helper.global_dictionary['logger'].Info(f'Init task {self.__class__.__name__}')
+
+
+        #Define the waiting time (seconds)
+        self.waitfor = 60*5
+
+        #Init the runDB
+        self.db = ConnectMongoDB()
+
+        #Init Rucio for later uploads and handling:
+        self.rc = RucioSummoner(helper.get_hostconfig("rucio_backend"))
+        self.rc.SetRucioAccount(helper.get_hostconfig('rucio_account'))
+        self.rc.SetConfigPath(helper.get_hostconfig("rucio_cli"))
+        self.rc.SetProxyTicket(helper.get_hostconfig('rucio_x509'))
+        self.rc.SetHost(helper.get_hostconfig('host'))
+        self.rc.ConfigHost()
+        self.rc.SetProxyTicket("rucio_x509")
+
+
+    def check_transfers(self):
+        cursor = self.db.db.find(
+            {'status': 'transferring'},
+#            {'number':7185},
+            {'number': 1, 'data': 1})
+
+        cursor = list(cursor)
+
+        helper.global_dictionary['logger'].Info('Check transfers : checking status of {0} runs'.format(len(cursor)))
+
+        for run in list(cursor):
+            # for each run, check the status of all REPLICATING rules
+            rucio_stati = []
+            for d in run['data']:
+                if d['host'] == 'rucio-catalogue':
+#                    if run['number']==7695 and d['status'] == 'error':
+#                        self.db.db.find_one_and_update({'_id': run['_id'],'data': {'$elemMatch': d}},
+#                                                       {'$set': {'data.$.status': 'transferring'}}
+#                                                   )                        
+                    if d['status'] != 'transferring':
+                        rucio_stati.append(d['status'])
+                    else:
+                        did = d['did']
+                        status = self.rc.CheckRule(did, d['location'])
+                        if status == 'REPLICATING':
+                            rucio_stati.append('transferring')
+                        elif status == 'OK':
+                            # update database
+                            helper.global_dictionary['logger'].Info('Check transfers : updating DB for run {0}, dtype {1}, location {2}'.format(run['number'], d['type'],d['location']))
+                            self.db.db.find_one_and_update({'_id': run['_id'],'data': {'$elemMatch': d}},
+                                                      {'$set': {'data.$.status': 'transferred'}}
+                            )
+                            rucio_stati.append('transferred')
+
+                        elif status == 'STUCK':
+                            self.db.db.find_one_and_update({'_id': run['_id'], 'data': {'$elemMatch': d}},
+                                                      {'$set': {'data.$.status': 'error'}}
+                            )
+                            rucio_stati.append('error')
+
+                            # are there any other rucio rules transferring?
+            if len(rucio_stati) > 0 and all([s == 'transferred' for s in rucio_stati]):
+                self.db.SetStatus(run['number'], 'transferred')
+
+
+
+
+
+
+    def run(self,*args, **kwargs):
+        helper.global_dictionary['logger'].Info(f'Run task {self.__class__.__name__}')
+
+
+        # Check transfers
+        self.check_transfers()
+        
+
+        return 0
+
+
+    def __del__(self):
+        pass

--- a/admix/tasks/clean_eb.py
+++ b/admix/tasks/clean_eb.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+import json
+import os
+from admix.helper import helper
+import time
+import shutil
+
+from admix.interfaces.database import ConnectMongoDB
+from admix.helper.decorator import Collector
+
+#get Rucio imports done:
+from admix.interfaces.rucio_dataformat import ConfigRucioDataFormat
+from admix.interfaces.rucio_summoner import RucioSummoner
+from admix.interfaces.destination import Destination
+from admix.interfaces.keyword import Keyword
+from admix.interfaces.templater import Templater
+from admix.utils import make_did
+
+@Collector
+class CleanEB():
+
+    def __init__(self):
+        pass
+
+    def init(self):
+        helper.global_dictionary['logger'].Info(f'Init task {self.__class__.__name__}')
+
+
+        #Define data types
+        self.DTYPES = helper.get_hostconfig()['rawtype']
+        self.DATADIR = helper.get_hostconfig()['path_data_to_upload']
+        self.periodic_check = helper.get_hostconfig()['upload_periodic_check']
+        self.RSES = helper.get_hostconfig()['rses']
+
+        #Init the runDB
+        self.db = ConnectMongoDB()
+
+        #We want the first and the last run:
+        self.gboundary = self.db.GetBoundary()
+        self.run_nb_min = self.gboundary['min_number']
+        self.run_nb_max = self.gboundary['max_number']
+        self.run_ts_min = self.gboundary['min_start_time']
+        self.run_ts_max = self.gboundary['max_start_time']
+
+        #Init the Rucio data format evaluator in three steps:
+        self.rc_reader = ConfigRucioDataFormat()
+        self.rc_reader.Config(helper.get_hostconfig('rucio_template'))
+
+        #This class will evaluate your destinations:
+        self.destination = Destination()
+
+        #Since we deal with an experiment, everything is predefine:
+        self.exp_temp = Templater()
+        self.exp_temp.Config(helper.get_hostconfig()['template'])
+
+        #Init a class to handle keyword strings:
+        self.keyw = Keyword()
+
+        #Init Rucio for later uploads and handling:
+        self.rc = RucioSummoner(helper.get_hostconfig("rucio_backend"))
+        self.rc.SetRucioAccount(helper.get_hostconfig('rucio_account'))
+        self.rc.SetConfigPath(helper.get_hostconfig("rucio_cli"))
+        self.rc.SetProxyTicket(helper.get_hostconfig('rucio_x509'))
+        self.rc.SetHost(helper.get_hostconfig('host'))
+        self.rc.ConfigHost()
+        self.rc.SetProxyTicket("rucio_x509")
+#        print(self.rc.Whoami())
+
+
+
+
+
+    def run(self,*args, **kwargs):
+        helper.global_dictionary['logger'].Info(f'Run task {self.__class__.__name__}')
+
+
+        # Get runs list to clean
+        cursor = self.db.db.find({
+#            'number': {"$lt": 7330},
+#            'number': {"$gt": 7300}
+            'number': 7319
+        },
+        {'_id': 1, 'number': 1, 'data': 1})
+
+        cursor = list(cursor)
+
+        helper.global_dictionary['logger'].Info('Runs that will be processed are {0}'.format([c["number"] for c in cursor]))
+
+        # Runs over all listed runs
+        for run in cursor:
+            number = run['number']
+            helper.global_dictionary['logger'].Info('Treating run {0}'.format(number))
+            for dtype in self.DTYPES:
+                helper.global_dictionary['logger'].Info('\t==> Looking for data type {0}'.format(dtype))
+                # get the datum for this datatype
+                datum = None
+                for d in run['data']:
+                    if d['type'] == dtype and 'eb' in d['host']:
+                        datum = d
+
+                if datum is None:
+                    helper.global_dictionary['logger'].Info('Data type not in eb')
+                    continue
+
+                file = datum['location'].split('/')[-1]
+                hash = file.split('-')[-1]
+
+                # create a DID to upload
+                did = make_did(number, dtype, hash)
+
+                # check if a rule already exists for this DID on any RSE
+                rses_with_rule = []
+                for rse in self.RSES:
+                    rucio_rule = self.rc.GetRule(upload_structure=did, rse=rse)
+                    if rucio_rule['exists']:
+                        if "LNGS_USERDISK"==rucio_rule['rse']:
+                            continue
+                        rses_with_rule.append(rucio_rule['rse'])
+                helper.global_dictionary['logger'].Info('\t==> Found in : {0}'.format(rses_with_rule))
+
+                minimum_number_acceptable_rses = 2
+
+                if len(rses_with_rule)>=minimum_number_acceptable_rses:
+
+                    helper.global_dictionary['logger'].Info('\t==> Deleted') 
+
+                    print(run['_id'],datum['type'],datum['host'])
+                    self.db.RemoveDatafield(run['_id'],datum)
+                    full_path = os.path.join(self.DATADIR, file)
+                    print(full_path)
+                    shutil.rmtree(full_path)
+
+        return 0
+
+
+    def __del__(self):
+        pass

--- a/admix/tasks/fix_upload.py
+++ b/admix/tasks/fix_upload.py
@@ -188,7 +188,7 @@ class FixUpload():
 
         # List runs to upload
         run = self.db.db.find_one({
-                            'number': my_number
+                            'number': number
                          },
                             {'number': 1, 'data': 1})
 
@@ -201,7 +201,7 @@ class FixUpload():
         # Performs uploads to all listed runs
         if 'number' in run:
             helper.global_dictionary['logger'].Info('Uploading run {0}'.format(number))
-            if my_dtype in self.DTYPES:
+            if dtype in self.DTYPES:
                 helper.global_dictionary['logger'].Info('\t==> Uploading {0}'.format(dtype))
                 # get the datum for this datatype
                 datum = None
@@ -232,7 +232,8 @@ class FixUpload():
                 helper.global_dictionary['logger'].Info('Rucio rule : {0}'.format(rucio_rule))
 
                 # if not in rucio already and no rule exists, upload into rucio
-                if not in_rucio and not rucio_rule['exists']:
+#                if not in_rucio and not rucio_rule['exists']:
+                if not rucio_rule['exists']:
                     result = self.rc.Upload(did,
                                        upload_path,
                                        'LNGS_USERDISK',
@@ -250,9 +251,9 @@ class FixUpload():
                              'protocol': 'rucio'
                          }
 
-                if rucio_rule['state'] == 'OK':
-                    if not in_rucio:
-                        self.db.AddDatafield(run['_id'], data_dict)
+#                if rucio_rule['state'] == 'OK':
+#                    if not in_rucio:
+#                        self.db.AddDatafield(run['_id'], data_dict)
 
                     # add a DID list that's easy to query by DB.GetDid
                     # check if did field exists yet or not
@@ -277,9 +278,9 @@ class FixUpload():
                 # finally, delete the eb copy
                 #self.remove_from_eb(number, dtype)
 
-            if time.time() - last_check > self.periodic_check:
-                self.check_transfers()
-                last_check = time.time()
+#            if time.time() - last_check > self.periodic_check:
+#                self.check_transfers()
+#                last_check = time.time()
 
 
         return 0

--- a/admix/tasks/upload_from_lngs.py
+++ b/admix/tasks/upload_from_lngs.py
@@ -26,10 +26,11 @@ class UploadFromLNGS():
         helper.global_dictionary['logger'].Info(f'Init task {self.__class__.__name__}')
 
 
-        open("/tmp/admix-upload_from_lngs", 'a').close()
+#        open("/tmp/admix-upload_from_lngs", 'a').close()
 
         #Define data types
         self.DTYPES = helper.get_hostconfig()['rawtype']
+#        self.DTYPES = ["pulse_counts"]
         self.DATADIR = helper.get_hostconfig()['path_data_to_upload']
         self.periodic_check = helper.get_hostconfig()['upload_periodic_check']
 
@@ -199,7 +200,7 @@ class UploadFromLNGS():
         ids_to_upload = self.find_data_to_upload()
 
         cursor = self.db.db.find({'_id': {"$in": ids_to_upload},
-#                             'number': 7558
+                             'number': 7947
 #                             'number': 7177
 #                                  'number': {"$gte": 7807}
                          },

--- a/admix/tasks/upload_from_lngs_single_thread.py
+++ b/admix/tasks/upload_from_lngs_single_thread.py
@@ -1,0 +1,250 @@
+# -*- coding: utf-8 -*-
+import json
+import os
+from admix.helper import helper
+import time
+import shutil
+
+from admix.interfaces.database import ConnectMongoDB
+from admix.helper.decorator import Collector
+
+#get Rucio imports done:
+from admix.interfaces.rucio_dataformat import ConfigRucioDataFormat
+from admix.interfaces.rucio_summoner import RucioSummoner
+from admix.interfaces.destination import Destination
+from admix.interfaces.keyword import Keyword
+from admix.interfaces.templater import Templater
+from admix.utils import make_did
+
+@Collector
+class UploadFromLNGSSingleThread():
+
+    def __init__(self):
+        pass
+
+    def init(self):
+        helper.global_dictionary['logger'].Info(f'Init task {self.__class__.__name__}')
+
+
+#        open("/tmp/admix-upload_from_lngs", 'a').close()
+
+        #Take all data types categories
+        self.NORECORDS_DTYPES = helper.get_hostconfig()['norecords_types']
+        self.RAW_RECORDS_DTYPES = helper.get_hostconfig()['raw_records_types']
+        self.RECORDS_DTYPES = helper.get_hostconfig()['records_types']
+
+        # Choose which RSE you want upload to
+        self.UPLOAD_TO = helper.get_hostconfig()['upload_to']
+
+        #Choose which data type you want to treat
+        self.DTYPES = self.RAW_RECORDS_DTYPES + self.RECORDS_DTYPES
+
+
+        self.DATADIR = helper.get_hostconfig()['path_data_to_upload']
+        self.periodic_check = helper.get_hostconfig()['upload_periodic_check']
+
+        #Init the runDB
+        self.db = ConnectMongoDB()
+
+        #We want the first and the last run:
+        self.gboundary = self.db.GetBoundary()
+        self.run_nb_min = self.gboundary['min_number']
+        self.run_nb_max = self.gboundary['max_number']
+        self.run_ts_min = self.gboundary['min_start_time']
+        self.run_ts_max = self.gboundary['max_start_time']
+
+        #Init the Rucio data format evaluator in three steps:
+        self.rc_reader = ConfigRucioDataFormat()
+        self.rc_reader.Config(helper.get_hostconfig('rucio_template'))
+
+        #This class will evaluate your destinations:
+        self.destination = Destination()
+
+        #Since we deal with an experiment, everything is predefine:
+        self.exp_temp = Templater()
+        self.exp_temp.Config(helper.get_hostconfig()['template'])
+
+        #Init a class to handle keyword strings:
+        self.keyw = Keyword()
+
+        #Init Rucio for later uploads and handling:
+        self.rc = RucioSummoner(helper.get_hostconfig("rucio_backend"))
+        self.rc.SetRucioAccount(helper.get_hostconfig('rucio_account'))
+        self.rc.SetConfigPath(helper.get_hostconfig("rucio_cli"))
+        self.rc.SetProxyTicket(helper.get_hostconfig('rucio_x509'))
+        self.rc.SetHost(helper.get_hostconfig('host'))
+        self.rc.ConfigHost()
+        self.rc.SetProxyTicket("rucio_x509")
+#        print(self.rc.Whoami())
+
+
+
+    def find_next_run_to_upload(self):
+        cursor = self.db.db.find({'status': 'eb_ready_to_upload'}, {'number': 1, 'data': 1})
+#        cursor = self.db.db.find({'status': 'uploading'}, {'number': 1, 'data': 1})
+        id_run = 0
+        min_run = float('inf')
+
+        for run in cursor:
+            if run['number']<8100:
+                continue
+            if run['number'] < min_run:
+                min_run = run['number']
+                id_run = run['_id']
+        return id_run
+
+
+
+
+
+    def add_rule(self,run_number, dtype, hash, rse, lifetime=None, update_db=True):
+        did = make_did(run_number, dtype, hash)
+        result = self.rc.AddRule(did, rse, lifetime=lifetime)
+        #if result == 1:
+        #   return
+        helper.global_dictionary['logger'].Info('\t==> Run {0}, data type {1}: rule added: {2} ---> {3}'.format(run_number,dtype,did,rse))
+
+        if update_db:
+            rucio_rule = self.rc.GetRule(did, rse=rse)
+            data_dict = {'host': "rucio-catalogue",
+                         'type': dtype,
+                         'location': rse,
+                         'lifetime': rucio_rule['expires'],
+                         'status': 'transferring',
+                         'did': did,
+                         'protocol': 'rucio'
+                     }
+            self.db.db.find_one_and_update({'number': run_number},
+                                      {'$set': {'status': 'transferring'}}
+                                  )
+
+            docid = self.db.db.find_one({'number': run_number}, {'_id': 1})['_id']
+            self.db.AddDatafield(docid, data_dict)
+
+
+    def add_conditional_rule(self,run_number, dtype, hash, from_rse, to_rse, lifetime=None, update_db=True):
+        did = make_did(run_number, dtype, hash)
+        result = self.rc.AddConditionalRule(did, from_rse, to_rse, lifetime=lifetime)
+        #if result == 1:
+        #   return
+        helper.global_dictionary['logger'].Info('\t==> Run {0}, data type {1}: conditional rule added: {2} ---> {3}'.format(run_number,dtype,did,to_rse))
+
+        if update_db:
+            rucio_rule = self.rc.GetRule(did, rse=to_rse)
+            data_dict = {'host': "rucio-catalogue",
+                         'type': dtype,
+                         'location': to_rse,
+                         'lifetime': rucio_rule['expires'],
+                         'status': 'transferring',
+                         'did': did,
+                         'protocol': 'rucio'
+                     }
+            self.db.db.find_one_and_update({'number': run_number},
+                                      {'$set': {'status': 'transferring'}}
+                                  )
+
+            docid = self.db.db.find_one({'number': run_number}, {'_id': 1})['_id']
+            self.db.AddDatafield(docid, data_dict)
+
+
+
+
+
+    def run(self,*args, **kwargs):
+        helper.global_dictionary['logger'].Info(f'Run task {self.__class__.__name__}')
+
+#        number = 8113
+#        dtype = "raw_records"
+#        hash = "rfzvpzj4mf"
+#        self.add_conditional_rule(number, dtype, hash, 'UC_OSG_USERDISK', 'CCIN2P3_USERDISK')
+#        return 0
+
+        # Get a new run to upload
+        id_to_upload = self.find_next_run_to_upload()
+        if id_to_upload == 0:
+             helper.global_dictionary['logger'].Info('No run available to upload')
+             return 0
+        run = self.db.db.find_one({'_id': id_to_upload}, {'number': 1, 'data': 1})
+        number = run['number']
+
+        # Book the run by setting its status to "uploading"
+        self.db.SetStatus(number, 'uploading')
+
+        # Performs upload on selected run
+
+
+        helper.global_dictionary['logger'].Info('Uploading run {0}'.format(number))
+
+        # loop on all data types we want to upload
+        for dtype in self.DTYPES:
+            helper.global_dictionary['logger'].Info('\t==> Run {0}, data type {1}: uploading'.format(number,dtype))
+
+            # get the datum for this datatype
+            datum = None
+            in_rucio = False
+            for d in run['data']:
+                if d['type'] == dtype and 'eb' in d['host']:
+                    datum = d
+
+                if d['type'] == dtype and d['host'] == 'rucio-catalogue':
+                    in_rucio = True
+
+            if datum is None:
+                helper.global_dictionary['logger'].Info('\t==> Run {0}, data type {1}: not found'.format(number,dtype))
+                continue
+
+            file = datum['location'].split('/')[-1]
+
+            hash = file.split('-')[-1]
+
+            upload_path = os.path.join(self.DATADIR, file)
+
+            # create a DID to upload
+            did = make_did(number, dtype, hash)
+
+            # check if a rule already exists for this DID on LNGS
+            rucio_rule = self.rc.GetRule(upload_structure=did, rse=self.UPLOAD_TO)
+#            helper.global_dictionary['logger'].Info('It was already in Rucio : {0}'.format(in_rucio))
+#            helper.global_dictionary['logger'].Info('Rucio rule : {0}'.format(rucio_rule))
+#            print("Did: ",did)
+#            print("Upload path: ",upload_path)
+
+            # if not in rucio already and no rule exists, upload into rucio
+            if not in_rucio and not rucio_rule['exists']:
+                result = self.rc.Upload(did,
+                                        upload_path,
+                                        self.UPLOAD_TO,
+                                        lifetime=None)
+                helper.global_dictionary['logger'].Info('\t==> Run {0}, data type {1}: uploaded ({2})'.format(number,dtype,did))
+                
+            # if upload was successful, tell runDB
+            rucio_rule = self.rc.GetRule(upload_structure=did, rse=self.UPLOAD_TO)
+            data_dict = {'host': "rucio-catalogue",
+                         'type': dtype,
+                         'location': self.UPLOAD_TO,
+                         'lifetime': rucio_rule['expires'],
+                         'status': 'transferred',
+                         'did': did,
+                         'protocol': 'rucio'
+                        }
+
+            if rucio_rule['state'] == 'OK':
+                if not in_rucio:
+                    self.db.AddDatafield(run['_id'], data_dict)
+
+            # set a rule to ship data on GRID
+#            for rse in ['UC_OSG_USERDISK']:
+#                self.add_rule(number, dtype, hash, rse)
+            self.add_rule(number, dtype, hash, 'UC_OSG_USERDISK')
+            self.add_conditional_rule(number, dtype, hash, 'UC_OSG_USERDISK', 'CCIN2P3_USERDISK')
+
+            # Finally, unbook the run by setting its status to "uploaded"
+            # (not needed since add_rule already flags it as "transferring"
+#            self.db.SetStatus(number, 'uploaded')
+
+
+        return 0
+
+
+    def __del__(self):
+        pass

--- a/scripts/admix_upload.py
+++ b/scripts/admix_upload.py
@@ -276,7 +276,7 @@ def purge():
                     rc.DeleteRule(rule_id)
 
                 # TEMPORARY: check if there are still copies on eb, if so remove them.
-                # remove_from_eb(run['number'], dtype)
+                remove_from_eb(run['number'], dtype)
         break
 
 
@@ -314,8 +314,8 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    #main()
     # clear_db()
-    #purge()
+    purge()
     #check_transfers()
 


### PR DESCRIPTION
This version includes new tasks meant to improve admix parallelization.

- UploadFromLNGSSingleThread. It replaces UploadFromLNGS. The old task was looking for all runs to be uploaded and created a long queue, while the new one just pick up e single run, booking it by using of run DB and then start the upload. This way, multiple admix instances of the same task can be started in parallel and each of them will take care, in parallel, of new runs

- CheckTransfers. It checks if Rucio completed the pending rules. If so, it updates the database, flagging ad "transferred" the data field for all runs and datatypes. If all data types are flagged as transferred, then the run status is flagged as "transferred"

- CleanEB. It deletes from EB data if there are at least two sites (besides LNGS) storing them

In addition, an extra task is added:

- MoveDataToRSE.  It is used to easily move data from one site to another one. Each transfer updated the run DB accordingly.

Finally, the rucio_api interface is enriched by a new method that allows transferring data from one site to another one (it uses the feature source-replica-expression from Rucio). This method is used both by UploadFromLNGSSingleThread (for instance, to systematically instruct Rucio to ship a new copy of data in European sites only after the copy in UC_OSG has arrived) and by MoveDataToRSE.

This pull request uses code that is already tested under xent-datamanager.


