### PR TITLE
Maintain information in ddoc when transferring with admix

### DIFF
--- a/admix/tasks/upload_from_lngs_single_thread.py
+++ b/admix/tasks/upload_from_lngs_single_thread.py
@@ -236,14 +236,15 @@ class UploadFromLNGSSingleThread():
 
                 # if the rule status is OK, then update the DB
                 if rucio_rule['state'] == 'OK':
-                    data_dict = {'host': "rucio-catalogue",
+                    data_dict = datum.copy()
+                    data_dict.update({'host': "rucio-catalogue",
                                  'type': dtype,
                                  'location': self.UPLOAD_TO,
                                  'lifetime': rucio_rule['expires'],
                                  'status': 'transferred',
                                  'did': did,
                                  'protocol': 'rucio'
-                             }
+                             })
                     self.db.AddDatafield(run['_id'], data_dict)
 
             # set a rule to ship data on GRID


### PR DESCRIPTION
**What info would we add to the ddoc**
In https://github.com/XENONnT/straxen/pull/165 I've updated bootstrax to put some useful info into the Data Document (ddoc) in the 'meta' field. At the moment, admix creates a new ddoc every time a document is uploaded. If we want to keep this info in the ddoc we might opt for copying the respective info and overwriting it with the admix/rucio specific info. See e.g. the info below:

![afbeelding](https://user-images.githubusercontent.com/22295914/89787977-b9be9c00-db1e-11ea-9c40-4518af8d063b.png)
_Perhaps we can also move the file-count field to the meta entry?_

**Why would this be useful**
I envisaged this to be a particular help for computing as questions like 'why does a transfer take long' or 'how far is my admix download' would be easy to check as we would have the info of how big the data is and how many files one should wait for.

**Disclaimer**
It looks like there are multiple scripts involved so my guess is that it should also be updated in other places. However, as far as I can tell this is the latest version.

**Possible cons**
It might make take somewhat more space in the runs database but this will surely not be the mayor contribution to the rundocs in database (see e.g. the daq_config entry).

