### PR TITLE
add tape as last resort for admix download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ target/
 
 *~
 bin
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,3 @@ install:
 script:
     touch /home/travis/.xenon_config
     tox
-
-# After you create the Github repo and add it to Travis, run the
-# travis_pypi_setup.py script to finish PyPI deployment setup
-#deploy:
-#  provider: pypi
-#  distributions: sdist bdist_wheel
-#  user: XeBoris
-#  password:
-#    secure: PLEASE_REPLACE_ME
-#  on:
-#    tags: true
-#    repo: XeBoris/admix
-#    python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,7 @@
 
 language: python
 python:
-  - 3.5
-  - 3.4
-  - 3.3
-  - 2.7
-  - 2.6
+    - 3.6
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ python:
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
     pip install -U tox-travis
-    # create an empty file for utilix
-    touch /home/travis/.xenon_config
+
 
 # command to run tests, e.g. python setup.py test
 script:
+    touch /home/travis/.xenon_config
     tox
 
 # After you create the Github repo and add it to Travis, run the

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,13 @@ script:
 
 # After you create the Github repo and add it to Travis, run the
 # travis_pypi_setup.py script to finish PyPI deployment setup
-deploy:
-  provider: pypi
-  distributions: sdist bdist_wheel
-  user: XeBoris
-  password:
-    secure: PLEASE_REPLACE_ME
-  on:
-    tags: true
-    repo: XeBoris/admix
-    python: 2.7
+#deploy:
+#  provider: pypi
+#  distributions: sdist bdist_wheel
+#  user: XeBoris
+#  password:
+#    secure: PLEASE_REPLACE_ME
+#  on:
+#    tags: true
+#    repo: XeBoris/admix
+#    python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ python:
 install: pip install -U tox-travis
 
 # command to run tests, e.g. python setup.py test
-script: tox
+script:
+    ls ; pwd ; cd admix ; ls ; pwd ;
+    tox
 
 # After you create the Github repo and add it to Travis, run the
 # travis_pypi_setup.py script to finish PyPI deployment setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ python:
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
     pip install -U tox-travis
-    pip install -U click
+    # create an empty file for utilix
+    touch /home/travis/.xenon_config
 
 # command to run tests, e.g. python setup.py test
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,12 @@ python:
   - 2.6
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -U tox-travis
+install:
+    pip install -U tox-travis
+    pip install -U click
 
 # command to run tests, e.g. python setup.py test
 script:
-    ls ; pwd ; cd admix ; ls ; pwd ;
     tox
 
 # After you create the Github repo and add it to Travis, run the

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include CONTRIBUTING.rst
 include HISTORY.rst
 include LICENSE
 include README.rst
+include requirements.txt
 
 recursive-include tests *
 recursive-exclude * __pycache__

--- a/admix/download.py
+++ b/admix/download.py
@@ -4,6 +4,7 @@ from argparse import ArgumentParser
 from admix.interfaces.rucio_summoner import RucioSummoner
 from admix.interfaces.database import ConnectMongoDB
 from admix.utils.naming import make_did
+import numpy as np
 try:
     from straxen import __version__
     straxen_version = __version__
@@ -24,7 +25,7 @@ def determine_rse(rse_list, glidein_country):
                   "SURFSARA_USERDISK"]
 
     US_SITES = ["UC_OSG_USERDISK", "UC_DALI_USERDISK"]
-
+    TAPE_SITES = ["CNAF_TAPE2_USERDISK"]
 
     if glidein_country == "US":
         for site in US_SITES:
@@ -53,6 +54,12 @@ def determine_rse(rse_list, glidein_country):
 
     if US_SITES[0] in rse_list:
         return US_SITES[0]
+    elif np.any([s in rse_list for s in TAPE_SITES]):
+        # This is our last resort and may be much slower. Nonetheless
+        # it's better than not returning any site.
+        for site in TAPE_SITES:
+            if site in rse_list:
+                return site
     else:
         raise AttributeError("cannot download data")
 

--- a/admix/interfaces/rucio_api.py
+++ b/admix/interfaces/rucio_api.py
@@ -49,8 +49,6 @@ class RucioAPI():
 
         :param enable_print: If True then enable print to terminal
         """
-        # Load rucio outside of the init
-        load_rucio()
         self._print_to_screen = enable_print
         self._rucio_ping = None
         self._rucio_account = os.environ.get("RUCIO_ACCOUNT")

--- a/admix/interfaces/rucio_api.py
+++ b/admix/interfaces/rucio_api.py
@@ -18,19 +18,18 @@ import datetime
 import os
 import json
 
-def load_rucio():
-    from rucio.client.client import Client
-    from rucio.client.uploadclient import UploadClient
-    # from admix.interfaces.uploadclient import UploadClient
-    from rucio.client.downloadclient import DownloadClient
-    from rucio.common.exception import DataIdentifierAlreadyExists
-    from rucio.common.exception import AccountNotFound
-    from rucio.common.exception import AccessDenied
-    from rucio.common.exception import Duplicate
-    from rucio.common.exception import NoFilesUploaded
-    from rucio.common.exception import NotAllFilesUploaded
-    from rucio.common.exception import DuplicateContent
-    from rucio.common.exception import DuplicateRule
+from rucio.client.client import Client
+from rucio.client.uploadclient import UploadClient
+# from admix.interfaces.uploadclient import UploadClient
+from rucio.client.downloadclient import DownloadClient
+from rucio.common.exception import DataIdentifierAlreadyExists
+from rucio.common.exception import AccountNotFound
+from rucio.common.exception import AccessDenied
+from rucio.common.exception import Duplicate
+from rucio.common.exception import NoFilesUploaded
+from rucio.common.exception import NotAllFilesUploaded
+from rucio.common.exception import DuplicateContent
+from rucio.common.exception import DuplicateRule
 
 
 @Collector

--- a/admix/interfaces/rucio_api.py
+++ b/admix/interfaces/rucio_api.py
@@ -8,18 +8,6 @@
 """
 #from __future__ import with_statement
 import os
-from rucio.client.client import Client
-from rucio.client.uploadclient import UploadClient
-#from admix.interfaces.uploadclient import UploadClient
-from rucio.client.downloadclient import DownloadClient
-from rucio.common.exception import DataIdentifierAlreadyExists
-from rucio.common.exception import AccountNotFound
-from rucio.common.exception import AccessDenied
-from rucio.common.exception import Duplicate
-from rucio.common.exception import NoFilesUploaded
-from rucio.common.exception import NotAllFilesUploaded
-from rucio.common.exception import DuplicateContent
-from rucio.common.exception import DuplicateRule
 
 from admix.helper.decorator import NameCollector, ClassCollector
 from admix.helper.decorator import Collector
@@ -29,6 +17,21 @@ import subprocess
 import datetime
 import os
 import json
+
+def load_rucio():
+    from rucio.client.client import Client
+    from rucio.client.uploadclient import UploadClient
+    # from admix.interfaces.uploadclient import UploadClient
+    from rucio.client.downloadclient import DownloadClient
+    from rucio.common.exception import DataIdentifierAlreadyExists
+    from rucio.common.exception import AccountNotFound
+    from rucio.common.exception import AccessDenied
+    from rucio.common.exception import Duplicate
+    from rucio.common.exception import NoFilesUploaded
+    from rucio.common.exception import NotAllFilesUploaded
+    from rucio.common.exception import DuplicateContent
+    from rucio.common.exception import DuplicateRule
+
 
 @Collector
 class RucioAPI():
@@ -47,6 +50,8 @@ class RucioAPI():
 
         :param enable_print: If True then enable print to terminal
         """
+        # Load rucio outside of the init
+        load_rucio()
         self._print_to_screen = enable_print
         self._rucio_ping = None
         self._rucio_account = os.environ.get("RUCIO_ACCOUNT")
@@ -487,7 +492,7 @@ class RucioAPI():
 
     def DeleteRule(self, rule_id):
         """Function: DeleteRule(...)
-        
+
         Deletes a replication rule.
         :param rule_id: A rucio rule id string
         """

--- a/admix/interfaces/rucio_summoner.py
+++ b/admix/interfaces/rucio_summoner.py
@@ -14,16 +14,14 @@ import datetime
 import os
 import json
 from admix.helper.decorator import NameCollector, ClassCollector
-
+from admix.interfaces.rucio_cli import RucioCLI
 import hashlib
 
 class RucioSummoner():
     def __init__(self, rucio_backend="API"):
         # Do imports outside inside the init so as not to raise errors
         # in rucio on travis tests
-
         from admix.interfaces.rucio_api import RucioAPI
-        from admix.interfaces.rucio_cli import RucioCLI
 
         self.rucio_backend=rucio_backend
         self.rucio_account = os.environ.get("RUCIO_ACCOUNT")

--- a/admix/interfaces/rucio_summoner.py
+++ b/admix/interfaces/rucio_summoner.py
@@ -13,14 +13,18 @@ import subprocess
 import datetime
 import os
 import json
-from admix.interfaces.rucio_api import RucioAPI
-from admix.interfaces.rucio_cli import RucioCLI
 from admix.helper.decorator import NameCollector, ClassCollector
 
 import hashlib
 
 class RucioSummoner():
     def __init__(self, rucio_backend="API"):
+        # Do imports outside inside the init so as not to raise errors
+        # in rucio on travis tests
+
+        from admix.interfaces.rucio_api import RucioAPI
+        from admix.interfaces.rucio_cli import RucioCLI
+
         self.rucio_backend=rucio_backend
         self.rucio_account = os.environ.get("RUCIO_ACCOUNT")
         self._rucio = None
@@ -409,7 +413,7 @@ class RucioSummoner():
                                           h2=t2,
                                           fname=i_filename)
                     result[i_filename] = lfn
-                    
+
 
         else:
             #assume tape storage (non-deterministic paths)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 git+git://github.com/XENONnT/utilix
 pymongo
+rucio-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 git+git://github.com/XENONnT/utilix
 pymongo
-rucio-client
+rucio-clients

--- a/setup.py
+++ b/setup.py
@@ -24,12 +24,10 @@ test_requirements = [
 ]
 
 setup(
-    name='admix',
+    name='xe-admix',
     version='0.2.0',
     description="advanced Data Management In Xenon (aDMIX)",
     long_description=readme + '\n\n' + history,
-    author="Boris Bauermeister",
-    author_email='Boris.Bauermeister@gmail.com',
     url='https://github.com/XENON1T/admix',
     packages=find_packages(include=['admix',
                                     'admix.interfaces',

--- a/tests/test_admix.py
+++ b/tests/test_admix.py
@@ -1,38 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import warnings
 """Tests for `admix` package."""
 
-# This test seems desperatly out of date
-# import unittest
-# from click.testing import CliRunner
-#
-# from admix import admix
-# from admix import cli
-#
-#
-# class TestAdmix(unittest.TestCase):
-#     """Tests for `admix` package."""
-#
-#     def setUp(self):
-#         """Set up test fixtures, if any."""
-#
-#     def tearDown(self):
-#         """Tear down test fixtures, if any."""
-#
-#     def test_000_something(self):
-#         """Test something."""
-#
-#     def test_command_line_interface(self):
-#         """Test the CLI."""
-#         runner = CliRunner()
-#         result = runner.invoke(cli.main)
-#         assert result.exit_code == 0
-#         assert 'admix.cli.main' in result.output
-#         help_result = runner.invoke(cli.main, ['--help'])
-#         assert help_result.exit_code == 0
-#         assert '--help  Show this message and exit.' in help_result.output
-
-# So we cannot load a Rucio file, this makes sense
+# The most basic test, can we be imported
 import admix
-

--- a/tests/test_admix.py
+++ b/tests/test_admix.py
@@ -3,32 +3,5 @@
 
 """Tests for `admix` package."""
 
-
-import unittest
-from click.testing import CliRunner
-
-from admix import admix
-from admix import cli
-
-
-class TestAdmix(unittest.TestCase):
-    """Tests for `admix` package."""
-
-    def setUp(self):
-        """Set up test fixtures, if any."""
-
-    def tearDown(self):
-        """Tear down test fixtures, if any."""
-
-    def test_000_something(self):
-        """Test something."""
-
-    def test_command_line_interface(self):
-        """Test the CLI."""
-        runner = CliRunner()
-        result = runner.invoke(cli.main)
-        assert result.exit_code == 0
-        assert 'admix.cli.main' in result.output
-        help_result = runner.invoke(cli.main, ['--help'])
-        assert help_result.exit_code == 0
-        assert '--help  Show this message and exit.' in help_result.output
+def test_admix():
+    import admix

--- a/tests/test_admix.py
+++ b/tests/test_admix.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
+import warnings
 """Tests for `admix` package."""
 
 # This test seems desperatly out of date
@@ -33,5 +33,9 @@
 #         assert help_result.exit_code == 0
 #         assert '--help  Show this message and exit.' in help_result.output
 
-import admix
-from admix import *
+# So we cannot load a Rucio file, this makes sense
+try:
+    import admix
+except RuntimeError as e:
+    warnings.warn(str(e))
+

--- a/tests/test_admix.py
+++ b/tests/test_admix.py
@@ -34,8 +34,5 @@ import warnings
 #         assert '--help  Show this message and exit.' in help_result.output
 
 # So we cannot load a Rucio file, this makes sense
-try:
-    import admix
-except RuntimeError as e:
-    warnings.warn(str(e))
+import admix
 

--- a/tests/test_admix.py
+++ b/tests/test_admix.py
@@ -3,32 +3,35 @@
 
 """Tests for `admix` package."""
 
+# This test seems desperatly out of date
+# import unittest
+# from click.testing import CliRunner
+#
+# from admix import admix
+# from admix import cli
+#
+#
+# class TestAdmix(unittest.TestCase):
+#     """Tests for `admix` package."""
+#
+#     def setUp(self):
+#         """Set up test fixtures, if any."""
+#
+#     def tearDown(self):
+#         """Tear down test fixtures, if any."""
+#
+#     def test_000_something(self):
+#         """Test something."""
+#
+#     def test_command_line_interface(self):
+#         """Test the CLI."""
+#         runner = CliRunner()
+#         result = runner.invoke(cli.main)
+#         assert result.exit_code == 0
+#         assert 'admix.cli.main' in result.output
+#         help_result = runner.invoke(cli.main, ['--help'])
+#         assert help_result.exit_code == 0
+#         assert '--help  Show this message and exit.' in help_result.output
 
-import unittest
-from click.testing import CliRunner
-
-from admix import admix
-from admix import cli
-
-
-class TestAdmix(unittest.TestCase):
-    """Tests for `admix` package."""
-
-    def setUp(self):
-        """Set up test fixtures, if any."""
-
-    def tearDown(self):
-        """Tear down test fixtures, if any."""
-
-    def test_000_something(self):
-        """Test something."""
-
-    def test_command_line_interface(self):
-        """Test the CLI."""
-        runner = CliRunner()
-        result = runner.invoke(cli.main)
-        assert result.exit_code == 0
-        assert 'admix.cli.main' in result.output
-        help_result = runner.invoke(cli.main, ['--help'])
-        assert help_result.exit_code == 0
-        assert '--help  Show this message and exit.' in help_result.output
+import admix
+from admix import *

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands=flake8 admix
 setenv =
     PYTHONPATH = {toxinidir}
 
-commands = ls ; pwd ; cd admix ; ls ; pwd ; python setup.py test
+commands =python setup.py test
 
 ; If you want to make tox run the tests with the same versions, create a
 ; requirements.txt with the pinned versions and uncomment the following lines:

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands=flake8 admix
 setenv =
     PYTHONPATH = {toxinidir}
 
-commands = python setup.py test
+commands = ls ; pwd ; cd admix ; ls ; pwd ; python setup.py test
 
 ; If you want to make tox run the tests with the same versions, create a
 ; requirements.txt with the pinned versions and uncomment the following lines:


### PR DESCRIPTION
Just an idea to make admix download a little easier. For users it's a bit strange if they cannot download while the data is already in Rucio. Although downloading from tape has it's downsides, it's still easier than having to manually check where it's stored and adding a flag to ``admix download --rse ...``.


**EDIT:**
By accident I also looked at travis. It turned out to be slightly different than I anticipated. E.g. the code is not python 2.7 compatible (was tested against) and there are deprecated placeholders e.g. for pypi and the tests don't seem in line with the current state of admix. 