### PR TITLE
New rucio naming scheme

### DIFF
--- a/admix/utils/naming.py
+++ b/admix/utils/naming.py
@@ -1,7 +1,13 @@
 
 
-
 def make_did(run_number, dtype, hash):
+    # batch scopes into bunches of 10k
+    scope = "xnt_%02d" % (run_number / 10000)
+    dataset = "%06d-%s-%s" % (run_number, dtype, hash)
+    return "%s:%s" % (scope, dataset)
+
+
+def make_did_old(run_number, dtype, hash):
     scope = 'xnt_%06d' % run_number
     dataset = "%s-%s" % (dtype, hash)
     return "%s:%s" % (scope, dataset)


### PR DESCRIPTION
This PR creates a new naming scheme for XENONnT data. Rather than creating a new scope for every ~1-hour run, there will be a single scope per 10k runs. Under this proposal, the naming would change from (choosing dummy number, type, hash):

```
'xnt_011000:records-abcdef'
```
to 
```
'xnt_01:011000-records-abcdef'
```

If we assume that we take 1-hour runs consistently for a year, we would have 24*365 = 8760 runs per year. There are often calibration runs etc that are shorter than one hour, so let's include an additional factor of ~10 to be conservative. We then expect no more than 100k runs in a calendar year. Assuming we operate for 5 years, that's <500k runs for the life of XENONnT. This would correspond to 50 scopes and thus 50 top-level directories in the rucio directory on the various endpoints. 

We chose a factor of 10k arbitrarily -- this can be increased if necessary. Another option could be to just use a single scope called `xnt`. This would make one top-level directory but then the sub-directories would be quite large.

