### PR TITLE
Download 1T data with admix download

### DIFF
--- a/admix/__init__.py
+++ b/admix/__init__.py
@@ -7,11 +7,30 @@ __version__ = '0.2.0'
 
 #interfaces:
 import os
+import logging
+from utilix import uconfig
+
+def get_logger():
+    logger = logging.getLogger("admix")
+    ch = logging.StreamHandler()
+    ch.setLevel(uconfig.logging_level)
+    logger.setLevel(uconfig.logging_level)
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+    return logger
+
+logger = get_logger()
+
 from admix.interfaces.rucio_dataformat import ConfigRucioDataFormat
 from admix.interfaces.rucio_summoner import RucioSummoner
 from admix.interfaces.destination import Destination
 from admix.interfaces.keyword import Keyword
 from admix.interfaces.templater import Templater
+
+
+
+
 
 
 #tasks:

--- a/admix/download.py
+++ b/admix/download.py
@@ -182,6 +182,9 @@ def get_did_1t(number, dtype):
                 d['status'] == 'transferred'):
                 return d['location']
 
+    # if get here, there is a problem finding the DID
+    raise ValueError(f"No rucio DID found for run {number} with dtype {dtype}")
+
 
 def download_1t(number, dtype, location='.',  tries=3, num_threads=3, **kwargs):
     # setup rucio client

--- a/admix/download.py
+++ b/admix/download.py
@@ -37,9 +37,15 @@ def determine_rse(rse_list, glidein_country):
         for site in US_SITES:
             if site in rse_list:
                 return site
+        for site in EURO_SITES:
+            if site in rse_list:
+                return site
 
     elif glidein_country == "EUROPE":
         for site in EURO_SITES:
+            if site in rse_list:
+                return site
+        for site in US_SITES:
             if site in rse_list:
                 return site
 
@@ -47,9 +53,15 @@ def determine_rse(rse_list, glidein_country):
         for site in EURO_SITES:
             if site in rse_list:
                 return site
+        for site in US_SITES:
+            if site in rse_list:
+                return site
 
     elif glidein_country == "NL":
         for site in reversed(EURO_SITES):
+            if site in rse_list:
+                return site
+        for site in US_SITES:
             if site in rse_list:
                 return site
 
@@ -57,9 +69,15 @@ def determine_rse(rse_list, glidein_country):
         for site in EURO_SITES:
             if site in rse_list:
                 return site
+        for site in US_SITES:
+            if site in rse_list:
+                return site
 
     elif glidein_country == "IT":
         for site in EURO_SITES:
+            if site in rse_list:
+                return site
+        for site in US_SITES:
             if site in rse_list:
                 return site
 
@@ -105,13 +123,9 @@ def download(number, dtype, hash, chunks=None, location='.',  tries=3, metadata=
             if r['state'] == 'OK':
                 rses.append(r['rse_expression'])
         # find closest one, otherwise start at the US end at TAPE
-        glidein_list = (os.environ.get('GLIDEIN_Country', 'US'), 'EUROPE', None)
-        for region in glidein_list:
-            try:
-                rse = determine_rse(rses, region)
-            except NoRSEForCountry as e:
-                if region is None:
-                    raise NoRSEForCountry('Data not found anywhere') from e
+        glidein_region = os.environ.get('GLIDEIN_Country', 'US')
+        rse = determine_rse(rses, glidein_region)
+        print(rse)
 
     if chunks:
         dids = []
@@ -185,14 +199,13 @@ def download_1t(number, dtype, location='.',  tries=3, num_threads=3, **kwargs):
             if r['state'] == 'OK':
                 rses.append(r['rse_expression'])
         # find closest one, otherwise start at the US end at TAPE
-        glidein_list = (os.environ.get('GLIDEIN_Country', 'US'), 'EUROPE', None)
-        for region in glidein_list:
-            try:
-                rse = determine_rse(rses, region)
-            except NoRSEForCountry as e:
-                if region is None:
-                    raise NoRSEForCountry('Data not found anywhere') from e
+        glidein_region = os.environ.get('GLIDEIN_Country', 'US')
+        rse = determine_rse(rses, glidein_region)
 
+    if dtype == 'raw':
+        # get run name
+        name = xe1t_coll.find_one({'number': number, 'detector': 'tpc'}, {'name': 1})['name']
+        location = os.path.join(location, name)
     os.makedirs(location, exist_ok=True)
 
     # TODO check if files already exist?

--- a/admix/interfaces/database.py
+++ b/admix/interfaces/database.py
@@ -1,5 +1,4 @@
-import pymongo
-from utilix.rundb import pymongo_collection
+from utilix.rundb import xent_collection
 import admix.helper.helper as helper
 import datetime
 
@@ -29,10 +28,10 @@ class ConnectMongoDB():
 
     def Connect(self):
         # nT runs DB
-        self.db = pymongo_collection('runs')
+        self.db = xent_collection()
 
         # for querying the hash collection for strax data types
-        self.contexts = pymongo_collection('contexts')
+        self.contexts = xent_collection('contexts')
 
     def GetQuery(self, query, reconnect=False, sort=[('_id',1)]):
         if reconnect == True:

--- a/admix/interfaces/rucio_api.py
+++ b/admix/interfaces/rucio_api.py
@@ -11,12 +11,14 @@ import os
 
 from admix.helper.decorator import NameCollector, ClassCollector
 from admix.helper.decorator import Collector
+from admix import logger
 import sys
 import tempfile
 import subprocess
 import datetime
 import os
 import json
+import logging
 
 from rucio.client.client import Client
 from rucio.client.uploadclient import UploadClient
@@ -103,7 +105,7 @@ class RucioAPI():
         """
         try:
             self._rucio_client = Client()
-            self._rucio_client_upload = UploadClient()
+            self._rucio_client_upload = UploadClient(logger=logger)
 #            self._rucio_client_upload = UploadClient(tracing=False)
 #            print("Tracing set to False")
             self._rucio_client_download = DownloadClient()
@@ -519,15 +521,7 @@ class RucioAPI():
         :return result: 0 on success, 1 on failure
 
         """
-        result = 1
-
-        try:
-            result = self._rucio_client_upload.upload(upload_dict)
-        except NoFilesUploaded as e:
-            print(e)
-        except NotAllFilesUploaded as e:
-            print(e)
-
+        result = self._rucio_client_upload.upload(upload_dict)
         return result
 
     def DownloadDids(self, items, num_threads=2, trace_custom_fields={}):

--- a/admix/interfaces/rucio_summoner.py
+++ b/admix/interfaces/rucio_summoner.py
@@ -16,6 +16,7 @@ import json
 from admix.helper.decorator import NameCollector, ClassCollector
 from admix.interfaces.rucio_cli import RucioCLI
 import hashlib
+from admix import logger
 
 class RucioSummoner():
     def __init__(self, rucio_backend="API"):
@@ -893,26 +894,29 @@ class RucioSummoner():
 
 
         # create scope. If scope exists already, exception will be handled silently unless verbose=True is passed
+        logger.debug(f"Creating scope {scope}, if it doesn't exist")
         self._rucio.CreateScope(account=self.rucio_account, scope=scope)
 
         # create dataset
-        self._rucio.CreateDataset(scope, dataset)
+        #logger.debug(f"Creating dataset {scope}:{dataset}")
+        #self._rucio.CreateDataset(scope, dataset)
 
         # add a rule for this dataset
-        self._rucio.AddRule([dict(scope=scope, name=dataset)], 1, rse, lifetime=lifetime)
-
+        #logger.debug(f"Creating a rule for {did} at {rse}")
+        #self._rucio.AddRule([dict(scope=scope, name=dataset)], 1, rse, lifetime=lifetime)
 
         # smallest lifetime is 1 day?
         if lifetime != None and int(lifetime) < 86400:
             lifetime = 86400
 
         #Prepare an upload dictionary which is used later to upload to Rucio
-        upload_dict = dict(path=upload_path + "/",
+        upload_dict = dict(path=upload_path,
                            rse=rse,
                            lifetime=lifetime,
                            did_scope=scope,
                            dataset_scope=scope,
-                           dataset_name=dataset
+                           dataset_name=dataset,
+                           #register_after_upload=True
                            )
 
         # finally, upload the dataset

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 utilix
 pymongo
-rucio-clients


### PR DESCRIPTION
This PR implements a `download_1t` function so that we can also download xenon1t data. It requires [utilix #29](https://github.com/XENONnT/utilix/pull/29) to be merged. 

From the command line, downloading xenon1t data would look like this:

```
admix-download {run_number} {dtype} --experiment xe1t
```

where `run_number` is the run number and `dtype` could be `raw`, `v6.8.0`, or `v6.10.1`. Note we are in the process of getting the important processed data uploaded to rucio but it is not complete yet. 



