### PR TITLE
Update check_transfers.py

### DIFF
--- a/admix/tasks/check_transfers.py
+++ b/admix/tasks/check_transfers.py
@@ -59,10 +59,8 @@ class CheckTransfers():
 
 
     def check_transfers(self):
-        cursor = self.db.db.find(
-            {'status': 'transferring'},
-#            {'number':10161},
-            {'number': 1, 'data': 1, 'bootstrax': 1})
+        cursor = self.db.db.find({'data': {'$elemMatch': {'status': 'transferring'}}},
+                                 {'number': 1, 'data': 1, 'bootstrax': 1})
 
         cursor = list(cursor)
 


### PR DESCRIPTION
@lucascottolavina could we do this instead so that admix checks all data entries for things that are transferring, rather than just the top level? Might be a little more streamlined. 

I'm having second-thoughts on the top level 'status' field. It becomes another thing to keep track of on top of the crazy amount of data types, versions etc. 

