### PR TITLE
Ensure to create a rule after upload if not existing yet

### DIFF
--- a/admix/clients.py
+++ b/admix/clients.py
@@ -4,6 +4,7 @@ from rucio.client.accountclient import AccountClient
 from rucio.client.rseclient import RSEClient
 from rucio.client.downloadclient import DownloadClient
 from rucio.client.uploadclient import UploadClient
+from rucio.client.ruleclient import RuleClient
 
 from . import logger
 
@@ -14,6 +15,7 @@ account_client = None
 rse_client = None
 download_client = None
 upload_client = None
+rule_client = None
 
 
 def _init_clients():
@@ -23,6 +25,7 @@ def _init_clients():
     global rse_client
     global download_client
     global upload_client
+    global rule_client
 
     rucio_client = Client()
     replica_client = ReplicaClient()
@@ -30,6 +33,7 @@ def _init_clients():
     rse_client = RSEClient()
     download_client = DownloadClient(logger=logger)
     upload_client = UploadClient()
+    rule_client = RuleClient()
 
 
 def needs_client(func):

--- a/admix/uploader.py
+++ b/admix/uploader.py
@@ -1,6 +1,6 @@
 import os.path
 from rucio.common.exception import Duplicate, DataIdentifierNotFound
-from .rucio import add_scope, list_files
+from .rucio import add_scope, list_files, get_rule
 from .utils import parse_did, db
 from . import clients
 
@@ -85,6 +85,8 @@ def upload(path, rse,
             db.update_data(number, data_dict)
         try:
             clients.upload_client.upload(to_upload)
+            if not get_rule(did,rse):
+                clients.rule_client.add_replication_rule(dids=[{'scope':scope,'name':name}],copies=1,rse_expression=rse)
         except Exception as e:
             if verbose:
                 print(f"Upload failed for {path}")


### PR DESCRIPTION
I have basically added under the command `upload_client.upload` a verification of the existence of the rule (with `get_rule`). If the rule has not been created, it creates it with `rule_client.add_replication_rule`. To make it work I had to include the Rucio rule_client class in clients.py file.

