### PR TITLE
Now uploader can add a dataset rule also if all its files were already uploaded

### DIFF
--- a/admix/uploader.py
+++ b/admix/uploader.py
@@ -85,8 +85,6 @@ def upload(path, rse,
             db.update_data(number, data_dict)
         try:
             clients.upload_client.upload(to_upload)
-            if not get_rule(did,rse):
-                clients.rule_client.add_replication_rule(dids=[{'scope':scope,'name':name}],copies=1,rse_expression=rse)
         except Exception as e:
             if verbose:
                 print(f"Upload failed for {path}")
@@ -106,4 +104,15 @@ def upload(path, rse,
     else:
         print(f"Nothing to upload at {path}")
 
+    try:
+        if not get_rule(did,rse):
+            clients.rule_client.add_replication_rule(dids=[{'scope':scope,'name':name}],copies=1,rse_expression=rse)
+            print(f"Missing rule has been added")
+    except Exception as e:
+        if verbose:
+            print(f"Insertion of rule failed")
+            print(e)
+        return did
+
+        
     return did


### PR DESCRIPTION
Now, uploader will always attempt to add a possibly missing rule after any upload request, no matter if it finally uploaded some files or not. This code has its own try-except piece of protection and has also some dedicated print so that a user can watch from the terminal output if the insertion of a rule was necessary or not.

