### PR TITLE
Transfer speed timeout as an option

### DIFF
--- a/admix/downloader.py
+++ b/admix/downloader.py
@@ -66,7 +66,10 @@ def determine_rse(rse_list):
     return
 
 
-def download_dids(dids, num_threads=8, transfer_speed_timeout=50, **kwargs):
+def download_dids(dids, num_threads=8, 
+                  transfer_speed_timeout=None, 
+                  transfer_timeout=3600,
+                  **kwargs):
     # build list of did info
     did_list = []
     for did in dids:
@@ -75,11 +78,12 @@ def download_dids(dids, num_threads=8, transfer_speed_timeout=50, **kwargs):
                         )
         did_list.append(did_dict)
     return clients.download_client.download_dids(did_list, num_threads=num_threads,
-                                                 transfer_speed_timeout=transfer_speed_timeout)
+                                                 transfer_speed_timeout=transfer_speed_timeout,
+                                                 transfer_timeout=transfer_timeout)
 
 
 def download(did, chunks=None, location='.',  tries=3, metadata=True,
-             num_threads=5, rse=None, transfer_speed_timeout=50):
+             num_threads=5, rse=None, transfer_speed_timeout=None, transfer_timeout=3600):
     """Function download()
 
     """
@@ -144,7 +148,8 @@ def download(did, chunks=None, location='.',  tries=3, metadata=True,
         try:
             result = download_dids(dids, base_dir=location, no_subdir=True, rse=rse, 
                                    num_threads=num_threads, 
-                                   transfer_speed_timeout=transfer_speed_timeout)
+                                   transfer_speed_timeout=transfer_speed_timeout,
+                                   transfer_timeout=transfer_timeout)
             success = True
         except:
             logger.debug(f"Download try #{_try} failed. Sleeping for {3*_try} seconds.")

--- a/admix/downloader.py
+++ b/admix/downloader.py
@@ -66,7 +66,7 @@ def determine_rse(rse_list):
     return
 
 
-def download_dids(dids, num_threads=8, **kwargs):
+def download_dids(dids, num_threads=8, transfer_speed_timeout=100, **kwargs):
     # build list of did info
     did_list = []
     for did in dids:
@@ -74,11 +74,12 @@ def download_dids(dids, num_threads=8, **kwargs):
                         **kwargs
                         )
         did_list.append(did_dict)
-    return clients.download_client.download_dids(did_list, num_threads=num_threads)
+    return clients.download_client.download_dids(did_list, num_threads=num_threads,
+                                                 transfer_speed_timeout=transfer_speed_timeout)
 
 
 def download(did, chunks=None, location='.',  tries=3, metadata=True,
-             num_threads=5, rse=None):
+             num_threads=5, rse=None, transfer_speed_timeout=100):
     """Function download()
 
     """
@@ -141,7 +142,9 @@ def download(did, chunks=None, location='.',  tries=3, metadata=True,
         if _try == tries:
             rse = None
         try:
-            result = download_dids(dids, base_dir=location, no_subdir=True, rse=rse, num_threads=num_threads)
+            result = download_dids(dids, base_dir=location, no_subdir=True, rse=rse, 
+                                   num_threads=num_threads, 
+                                   transfer_speed_timeout=transfer_speed_timeout)
             success = True
         except:
             logger.debug(f"Download try #{_try} failed. Sleeping for {3*_try} seconds.")

--- a/admix/downloader.py
+++ b/admix/downloader.py
@@ -66,7 +66,7 @@ def determine_rse(rse_list):
     return
 
 
-def download_dids(dids, num_threads=8, transfer_speed_timeout=100, **kwargs):
+def download_dids(dids, num_threads=8, transfer_speed_timeout=50, **kwargs):
     # build list of did info
     did_list = []
     for did in dids:
@@ -79,7 +79,7 @@ def download_dids(dids, num_threads=8, transfer_speed_timeout=100, **kwargs):
 
 
 def download(did, chunks=None, location='.',  tries=3, metadata=True,
-             num_threads=5, rse=None, transfer_speed_timeout=100):
+             num_threads=5, rse=None, transfer_speed_timeout=50):
     """Function download()
 
     """

--- a/bin/admix-download
+++ b/bin/admix-download
@@ -35,7 +35,7 @@ def main():
                          default='xenonnt_online')
     parser.add_argument('--straxen_version', help='straxen version', default=None)
     parser.add_argument('--experiment', help="xent or xe1t", choices=['xe1t', 'xent'], default='xent')
-    parser.add_argument('--transfer_speed_timeout', help='Minimum allowed transfer speed (in KBps)', default=100, type=int)
+    parser.add_argument('--transfer_speed_timeout', help='Minimum allowed transfer speed (in KBps)', default=50, type=int)
 
     args = parser.parse_args()
 

--- a/bin/admix-download
+++ b/bin/admix-download
@@ -35,7 +35,7 @@ def main():
                          default='xenonnt_online')
     parser.add_argument('--straxen_version', help='straxen version', default=None)
     parser.add_argument('--experiment', help="xent or xe1t", choices=['xe1t', 'xent'], default='xent')
-    parser.add_argument('--transfer_speed_timeout', help='Minimum allowed transfer speed (in KBps)', default=50, type=int)
+    parser.add_argument('--transfer_speed_timeout', help='Minimum allowed transfer speed (in KBps)', default=None, type=int)
 
     args = parser.parse_args()
 

--- a/bin/admix-download
+++ b/bin/admix-download
@@ -35,6 +35,7 @@ def main():
                          default='xenonnt_online')
     parser.add_argument('--straxen_version', help='straxen version', default=None)
     parser.add_argument('--experiment', help="xent or xe1t", choices=['xe1t', 'xent'], default='xent')
+    parser.add_argument('--transfer_speed_timeout', help='Minimum allowed transfer speed (in KBps)', default=100, type=int)
 
     args = parser.parse_args()
 
@@ -71,7 +72,8 @@ def main():
         did = make_did(args.number, args.dtype, hash)
 
         downloaded = download(did, chunks=chunks, location=args.dir, tries=args.tries,
-                              rse=args.rse, num_threads=args.threads)
+                              rse=args.rse, num_threads=args.threads, 
+                              transfer_speed_timeout=args.transfer_speed_timeout)
 
         print(f"Download of {len(downloaded)} files finished.")
 

--- a/bin/admix-download
+++ b/bin/admix-download
@@ -36,6 +36,7 @@ def main():
     parser.add_argument('--straxen_version', help='straxen version', default=None)
     parser.add_argument('--experiment', help="xent or xe1t", choices=['xe1t', 'xent'], default='xent')
     parser.add_argument('--transfer_speed_timeout', help='Minimum allowed transfer speed (in KBps)', default=None, type=int)
+    parser.add_argument('--transfer_timeout', help='Maximum allowed transfer time (in seconds)', default=3600, type=int)
 
     args = parser.parse_args()
 
@@ -72,7 +73,8 @@ def main():
         did = make_did(args.number, args.dtype, hash)
 
         downloaded = download(did, chunks=chunks, location=args.dir, tries=args.tries,
-                              rse=args.rse, num_threads=args.threads, 
+                              rse=args.rse, num_threads=args.threads,
+                              transfer_timeout=args.transfer_timeout, 
                               transfer_speed_timeout=args.transfer_speed_timeout)
 
         print(f"Download of {len(downloaded)} files finished.")


### PR DESCRIPTION
Users have been reporting that admix-download fails often especially for datasets on tape, while using rucio command line tool usually can succeed. We have made the hypothesis that "the direct rucio command is more "patient" while the admix one not". See here for discussion in [slack](https://xenonnt.slack.com/archives/C016UJZ090B/p1697041609404029). 

After a little bit diving into rucio python client api, I find that there are two time out mechanism in `rucio.client.downloadclient.download_dids`:

- Killed when time exceeds a specified timeout threshold, namely `transfer_timeout `. This is default to `None`, and we have NOT overwritten it.
- Timeout after an inferred timeout threshold, by `transfer_speed_timeout`. This is [default](https://github.com/rucio/rucio/blob/4380d0247965f5db7ac05c25c48891dc0a840937/lib/rucio/client/downloadclient.py#L273) to `500` in unit of KBps. 

I suspect that the second case is contributing to downloading failure in `admix-download`, consider that for smaller files (chunks in `raw_records`), 500KBps could infer a quite small timeout, shorter than enough time for staging from tapes, which then could trigger the failure. 

So here, we propose the solution to change the default `transfer_speed_timeout` from 500KBps to 50KBps, which should give us 10 times equivalent timeout threshold. If not enough, users can give `admix-download` a even smaller `transfer_speed_timeout ` by passing parameter like

```
# 2KBps as minimal transfer speed timeout
admix-download 066666 raw_records --transfer_speed_timeout 2 
```

It is worth noting that a more elegant solution would be to implement an "interception" for timeout, which matches the time required to stage, for the tape sites.