### PR TITLE
Revert "Transfer speed timeout as an option"

### DIFF
--- a/admix/downloader.py
+++ b/admix/downloader.py
@@ -66,10 +66,7 @@ def determine_rse(rse_list):
     return
 
 
-def download_dids(dids, num_threads=8, 
-                  transfer_speed_timeout=None, 
-                  transfer_timeout=3600,
-                  **kwargs):
+def download_dids(dids, num_threads=8, **kwargs):
     # build list of did info
     did_list = []
     for did in dids:
@@ -77,13 +74,11 @@ def download_dids(dids, num_threads=8,
                         **kwargs
                         )
         did_list.append(did_dict)
-    return clients.download_client.download_dids(did_list, num_threads=num_threads,
-                                                 transfer_speed_timeout=transfer_speed_timeout,
-                                                 transfer_timeout=transfer_timeout)
+    return clients.download_client.download_dids(did_list, num_threads=num_threads)
 
 
 def download(did, chunks=None, location='.',  tries=3, metadata=True,
-             num_threads=5, rse=None, transfer_speed_timeout=None, transfer_timeout=3600):
+             num_threads=5, rse=None):
     """Function download()
 
     """
@@ -146,10 +141,7 @@ def download(did, chunks=None, location='.',  tries=3, metadata=True,
         if _try == tries:
             rse = None
         try:
-            result = download_dids(dids, base_dir=location, no_subdir=True, rse=rse, 
-                                   num_threads=num_threads, 
-                                   transfer_speed_timeout=transfer_speed_timeout,
-                                   transfer_timeout=transfer_timeout)
+            result = download_dids(dids, base_dir=location, no_subdir=True, rse=rse, num_threads=num_threads)
             success = True
         except:
             logger.debug(f"Download try #{_try} failed. Sleeping for {3*_try} seconds.")

--- a/bin/admix-download
+++ b/bin/admix-download
@@ -35,8 +35,6 @@ def main():
                          default='xenonnt_online')
     parser.add_argument('--straxen_version', help='straxen version', default=None)
     parser.add_argument('--experiment', help="xent or xe1t", choices=['xe1t', 'xent'], default='xent')
-    parser.add_argument('--transfer_speed_timeout', help='Minimum allowed transfer speed (in KBps)', default=None, type=int)
-    parser.add_argument('--transfer_timeout', help='Maximum allowed transfer time (in seconds)', default=3600, type=int)
 
     args = parser.parse_args()
 
@@ -73,9 +71,7 @@ def main():
         did = make_did(args.number, args.dtype, hash)
 
         downloaded = download(did, chunks=chunks, location=args.dir, tries=args.tries,
-                              rse=args.rse, num_threads=args.threads,
-                              transfer_timeout=args.transfer_timeout, 
-                              transfer_speed_timeout=args.transfer_speed_timeout)
+                              rse=args.rse, num_threads=args.threads)
 
         print(f"Download of {len(downloaded)} files finished.")
 


### PR DESCRIPTION
Seems there is some problem in testing. Without useful debugging info... Let's revert for now and debug a bit
```
/cvmfs/xenon.opensciencegrid.org/releases/nT/development/anaconda/envs/XENONnT_development/lib/python3.9/site-packages/straxen/url_config.py:756: UserWarning: From straxen version 2.1.0 onward, URLConfig parameterswill be sorted alphabetically before being passed to the plugins, this will change the lineage hash for non-sorted URLs. To load data processed with non-sorted URLs, you will need to use an older version.
  warnings.warn(
2023-11-09 23:42:47,407 - admix - INFO - Downloading xnt_053505:lone_hits-euocvpkv3y from UC_OSG_USERDISK
2023-11-09 23:42:47,407 - admix - DEBUG - Download try #1 failed. Sleeping for 3 seconds.
2023-11-09 23:42:50,411 - admix - DEBUG - Download try #2 failed. Sleeping for 6 seconds.
2023-11-09 23:42:59,419 - admix - DEBUG - Download try #3 failed. Sleeping for 9 seconds.
```