### PR TITLE
Added preupload function to fix issues on failed uploads

### DIFF
--- a/admix/__init__.py
+++ b/admix/__init__.py
@@ -26,6 +26,7 @@ DEFAULT_CONFIG = os.path.join(PKGDIR, 'config', 'default.config')
 from . import utils
 from .downloader import download
 from .uploader import upload
+from .uploader import preupload
 from . import manager
 from . import monitor
 from . import validator

--- a/admix/clients.py
+++ b/admix/clients.py
@@ -5,6 +5,7 @@ from rucio.client.rseclient import RSEClient
 from rucio.client.downloadclient import DownloadClient
 from rucio.client.uploadclient import UploadClient
 from rucio.client.ruleclient import RuleClient
+from rucio.client.didclient import DIDClient
 
 from . import logger
 
@@ -16,7 +17,7 @@ rse_client = None
 download_client = None
 upload_client = None
 rule_client = None
-
+did_client = None
 
 def _init_clients():
     global rucio_client
@@ -26,6 +27,7 @@ def _init_clients():
     global download_client
     global upload_client
     global rule_client
+    global did_client
 
     rucio_client = Client()
     replica_client = ReplicaClient()
@@ -34,7 +36,7 @@ def _init_clients():
     download_client = DownloadClient(logger=logger)
     upload_client = UploadClient()
     rule_client = RuleClient()
-
+    did_client = DIDClient()
 
 def needs_client(func):
     def wrapped(*args, **kwargs):

--- a/admix/uploader.py
+++ b/admix/uploader.py
@@ -5,9 +5,31 @@ from .utils import parse_did, db
 from . import clients
 
 
+
 def get_default_scope():
     return 'user.' + clients.upload_client.client.account
 
+def preupload(path, rse, did):
+
+    if not os.path.isdir(path):
+        return
+
+    local_files = os.listdir(path)
+    nfiles = len(local_files)
+    scope, name = did.split(':')
+    try:
+        clients.did_client.add_dataset(scope,name)
+    except:
+        print("DID {0} already exists".format(did))
+    for local_file in local_files:
+        try:
+            clients.did_client.attach_dids(scope,name,[{'scope':scope,'name':local_file}])
+        except:
+            print("File {0} could not be attached".format(local_file))
+    try:
+        clients.rule_client.add_replication_rule([{'scope':scope,'name':name}],1,rse)
+    except:
+        print("The rule for DID {0} already exists".format(did))
 
 # TODO could we make this use multithreading or multiprocessing to speed things up?
 def upload(path, rse, 

--- a/admix/uploader.py
+++ b/admix/uploader.py
@@ -10,7 +10,17 @@ def get_default_scope():
     return 'user.' + clients.upload_client.client.account
 
 def preupload(path, rse, did):
-
+    """
+    A function supposed to be run before upload to avoid orphan files failing the upload. 
+    It does the following
+        - It adds the dataset associated to the did we wanted to upload
+        - It loops over all local files to be uploaded, so to know their number and their names. 
+          For each file, it searches in Rucio catalogue if such a filename is already present. 
+          If so, it attaches it to the dataset
+        - Finally, it creates a replication rule on the RSE (the RSE is an input parameter of the 
+          preupload function, however, it's important that the RSE must be the same chosen by the 
+          previous upload attempt). After this latest operation, the did will show up in Rucio.
+    """
     if not os.path.isdir(path):
         return
 


### PR DESCRIPTION
Added a preupload function to fix issues on failed uploads. The idea is that, in case an upload fails, there might be "orphan" files (files successfully copied to the target RSE by Rucio, with Rucio that has been able to checksum them and create metadata for them, however not attached to the dataset rule, and the rule of the dataset often not even created).

In that case, the preupload function needs to be run before retrying again the upload, because the preupload does the following actions:

- It adds the dataset associated to the did we wanted to upload
- It loops over all local files to be uploaded, so to know their number and their names. For each file, it searches in Rucio catalogue if such a filename is already present. If so, it attaches it to the dataset
- finally, it creates a replication rule on the RSE (the RSE is an input parameter of the preupload function, however, it's important that the RSE must be the same chosen by the previous upload attempt). After this latest operation, the did will show up in Rucio

As a conclusion, after this preupload, the did shows up in Rucio, but containing only the orphan files. Then the upload function needs to be executed again so that all remaining files can be uploaded and the did will be complete.