### PR TITLE
Added a new function that stages a dataset, also integrated with the download function

### DIFF
--- a/admix/downloader.py
+++ b/admix/downloader.py
@@ -79,7 +79,7 @@ def download_dids(dids, num_threads=8, **kwargs):
 
 
 def download(did, chunks=None, location='.',  tries=3, metadata=True,
-             only_metadata=False, num_threads=8, rse=None, stage=None):
+             only_metadata=False, num_threads=5, rse=None, stage=None):
     """Function download()
 
     """

--- a/admix/downloader.py
+++ b/admix/downloader.py
@@ -6,6 +6,7 @@ import socket
 import admix.rucio
 from .utils import xe1t_runs_collection
 from .rucio import list_rules, get_did_type, get_rses
+from .manager import bring_online
 from . import logger
 from . import clients
 try:
@@ -78,7 +79,7 @@ def download_dids(dids, num_threads=8, **kwargs):
 
 
 def download(did, chunks=None, location='.',  tries=3, metadata=True,
-             only_metadata=False, num_threads=5, rse=None):
+             only_metadata=False, num_threads=8, rse=None, stage=None):
     """Function download()
 
     """
@@ -132,6 +133,12 @@ def download(did, chunks=None, location='.',  tries=3, metadata=True,
         rses = get_rses(did, state='OK')
         # find closest rse
         rse = determine_rse(rses)
+
+
+    if stage:
+        logger.info(f"Staging {len(dids)} file{'s'*(len(dids)>1)} of {did} from {rse}")        
+        bring_online(did,rse)
+
 
     if chunks:
         logger.info(f"Downloading {len(dids)} file{'s'*(len(dids)>1)} of {did} from {rse}")

--- a/admix/manager.py
+++ b/admix/manager.py
@@ -10,10 +10,13 @@ from tqdm import tqdm
 from rucio.common.exception import DataIdentifierNotFound
 
 import admix.rucio
+from . import clients
 from . import rucio, logger
 from . import utils
 from .utils import db
 
+import gfal2
+import time
 
 def has_metadata(did):
     scope, dset = did.split(':')
@@ -397,3 +400,65 @@ def clean_local_dir(path, before_straxen_version, ensure_rucio=False, dry_run=Tr
         print(f"Files that we can delete written to {tmpfile}")
 
 
+def bring_online(did,rse):
+    print("Bringing online {0} from {1}".format(did,rse))
+
+    if rse not in ['SURFSARA_USERDISK','CNAF_TAPE3_USERDISK','CNAF_TAPE2_USERDISK','CNAF_TAPE_USERDISK','CCIN2P3_USERDISK']:
+        print("{0} is not a tape-based RSE. Staging is not required".format(rse))
+        return
+
+    scope = did.split(':')[0]
+    dataset = did.split(':')[1]
+
+    file_replicas = clients.replica_client.list_replicas([{'scope':scope,'name': dataset}],rse_expression=rse)
+#    file_replicas = rucio.list_file_replicas(did,rse=rse)
+    files = [list(replica['pfns'].keys())[0] for replica in file_replicas]
+#    files = rucio.list_file_replicas(did,rse=rse)
+
+    print("Bringing online {0} files".format(len(files)))
+
+    if rse=="SURFSARA_USERDISK":
+        for i, file in enumerate(files):
+            files[i] = files[i].replace("gsiftp","srm")
+            files[i] = files[i].replace("gridftp","srm")
+            files[i] = files[i].replace("2811","8443")
+    if rse=="CCIN2P3_USERDISK":
+        for i, file in enumerate(files):
+            files[i] = files[i].replace("gsiftp","srm")
+            files[i] = files[i].replace("ccdcacli392.in2p3.fr","ccsrm02.in2p3.fr")
+            files[i] = files[i].replace("2811","8443")
+
+    #print(files)                                                                                                                                                                                                                       
+    ctx = gfal2.creat_context()
+
+    try:
+        # bring_online(surls, pintime, timeout, async)                                                                                                                                                                                  
+        # Parameters:                                                                                                                                                                                                                   
+        #   surls is the given [srmlist] argument                                                                                                                                                                                       
+        #   pintime in seconds (how long should the file stay PINNED), e.g. value 1209600 will pin files for two weeks                                                                                                                  
+        #   timeout of request in seconds, e.g. value 604800 will timeout the requests after a week                                                                                                                                     
+        #   async is asynchronous request (does not block if != 0)                                                                                                                                                                      
+        pintime = 3600*48
+        timeout = 3600
+        (status, token) = ctx.bring_online(files, pintime, timeout, True)
+        if token:
+            print(("Got token %s" % token))
+        else:
+            print("No token was returned. Are all files online?")
+    except gfal2.GError as e:
+        print("Could not bring the files online:")
+        print(("\t", e.message))
+        print(("\t Code", e.code))
+
+    print("Waiting until they are all online... (this might take time)")
+    while True:
+        errors = ctx.bring_online_poll(files, token)
+        ncompleted = 0
+        for surl, error in zip(files, errors):
+            if not error:
+                ncompleted += 1
+        print("So far {0} files have been staged".format(ncompleted))
+        if ncompleted == len(files):
+            print("Staging of {0} files successfully completed".format(ncompleted))
+            break
+        time.sleep(60)

--- a/admix/utils.py
+++ b/admix/utils.py
@@ -66,3 +66,5 @@ def parse_dirname(dirname):
     number, dtype, lineage_hash = dirname.split('-')
     number = int(number)
     return number, dtype, lineage_hash
+
+

--- a/bin/admix-download
+++ b/bin/admix-download
@@ -37,6 +37,7 @@ def main():
     parser.add_argument('--straxen_version', help='straxen version', default=None)
     parser.add_argument('--experiment', help="xent or xe1t", choices=['xe1t', 'xent'], default='xent')
     parser.add_argument('--hash', help='force to use specific strax hash', default=None)
+    parser.add_argument("--stage", help="Stage data before downloading (useful for tape-based RSEs)", action="store_true")
 
     args = parser.parse_args()
 
@@ -78,6 +79,7 @@ def main():
         downloaded = download(
             did, chunks=chunks, location=args.dir, tries=args.tries,
             only_metadata=args.metadata, rse=args.rse, num_threads=args.threads,
+            stage = args.stage,
         )
 
         print(f"Download of {len(downloaded)} files finished.")


### PR DESCRIPTION
A new function has been created, in the file `admix/manager.py`, named `bring_online(did,rse)`. It requests, through gfal commands, data to be pre-staged (after checking that they are stored in a tape-based storage system) and waits until data are all cached on the disk buffer (hence, available to be more efficiently copied or downloaded). This PR includes:

- the implementation of this new function
- the modification of the `admix/downloader.py` function to that it can optionally (`stage=True` as input) activate a pre-stage before a download
- the new flag `--stage` in `bin/admix-download` executable, that, if added, enables this feature before the actual download.

As a result, for users interested to download data from tape-based storage systems, it suffices to add the flag `--stage` when they run the admix-download command. 

In the case this flag is activated for data not stored in tape-based systems (so far a not elegant solution is done, hardcoding the names of the tape-based RSEs), the program will just skip the staging. So, a priori, the stage flag could also be activated in any occasion if you don't know where data are stored. This new feature still needs to be tested massively, that's why it can be currently activated only with that flag. Once it is fully validated, we can make the stage active by default, so that the choice of staging will be transparent to users.
