### PR TITLE
Add more fields when updating DB

### DIFF
--- a/admix/uploader.py
+++ b/admix/uploader.py
@@ -42,9 +42,16 @@ def preupload(path, rse, did):
         print("The rule for DID {0} already exists".format(did))
 
 # TODO could we make this use multithreading or multiprocessing to speed things up?
-def upload(path, rse, 
-           register_after_upload=False, verbose=True, did=None, lifetime=None, update_db=False):
-
+def upload(
+    path,
+    rse,
+    register_after_upload=False,
+    verbose=True,
+    did=None,
+    lifetime=None,
+    update_db=False,
+    miscellaneous=None,
+):
     # set scope initially to default one. will overwrite it below if did passed
     scope = get_default_scope()
 
@@ -132,13 +139,14 @@ def upload(path, rse,
                                      size_mb=size,
                                      file_count=len(files)
                                      )
-            for key in miscellaneous:
-                if key not in data_dict:
-                    data_dict[key] = miscellaneous[key]
-                else:
-                    raise ValueError(
-                        f"Key {key} provided in miscellaneous is already in data_dict!"
-                    )
+            if miscellaneous:
+                for key in miscellaneous:
+                    if key not in data_dict:
+                        data_dict[key] = miscellaneous[key]
+                    else:
+                        raise ValueError(
+                            f"Key {key} provided in miscellaneous is already in data_dict!"
+                        )
             db.update_data(number, data_dict)
     else:
         print(f"Nothing to upload at {path}")

--- a/admix/uploader.py
+++ b/admix/uploader.py
@@ -132,6 +132,13 @@ def upload(path, rse,
                                      size_mb=size,
                                      file_count=len(files)
                                      )
+            for key in miscellaneous:
+                if key not in data_dict:
+                    data_dict[key] = miscellaneous[key]
+                else:
+                    raise ValueError(
+                        f"Key {key} provided in miscellaneous is already in data_dict!"
+                    )
             db.update_data(number, data_dict)
     else:
         print(f"Nothing to upload at {path}")


### PR DESCRIPTION
Close: https://github.com/XENONnT/admix/issues/56

After this PR, we can use:

```
miscellaneous = {"creation_time": datetime.datetime.utcnow().isoformat(), "creation_place": "OSG"}
admix.upload(path, rse=rse, did=dataset_did, update_db=update_db, miscellaneous=miscellaneous)
```

to replace these lines: https://github.com/XENONnT/outsource/blob/0f5856a7d4aaa3c41807ae34be1e342efcec68b9/outsource/workflow/runstrax.py#L608-L609.

This PR also provides the opportunity for uploading more fields.

Related [slack thread](https://xenonnt.slack.com/archives/C07BT5HD6NB/p1727023364725939)