### PR TITLE
Add `LazyInit` class to only init when getting attribute of `pymongo.MongoClient`

### DIFF
--- a/admix/downloader.py
+++ b/admix/downloader.py
@@ -4,7 +4,7 @@ from argparse import ArgumentParser
 import socket
 
 import admix.rucio
-from .utils import xe1t_runs_collection
+from . import utils
 from .rucio import list_rules, get_did_type, get_rses
 from .manager import bring_online
 from . import logger
@@ -170,7 +170,7 @@ def download(did, chunks=None, location='.',  tries=3, metadata=True,
 
 def get_did_1t(number, dtype):
     query = {'number': number}
-    cursor = xe1t_runs_collection.find_one(query, {'number': 1, 'name': 1, 'data': 1})
+    cursor = utils.xe1t_runs_collection.find_one(query, {'number': 1, 'name': 1, 'data': 1})
     for d in cursor['data']:
         if dtype == 'raw':
             if d['type'] == 'raw' and d['host'] == 'rucio-catalogue' and d['status'] == 'transferred':
@@ -198,7 +198,7 @@ def download_1t(number, dtype, location='.',  tries=3, num_threads=5, **kwargs):
 
     if dtype == 'raw':
         # get run name
-        name = xe1t_runs_collection.find_one({'number': number, 'detector': 'tpc'}, {'name': 1})['name']
+        name = utils.xe1t_runs_collection.find_one({'number': number, 'detector': 'tpc'}, {'name': 1})['name']
         location = os.path.join(location, name)
 
     os.makedirs(location, exist_ok=True)

--- a/admix/utils.py
+++ b/admix/utils.py
@@ -13,9 +13,26 @@ except:
     db = None
 
 
-xent_runs_collection = xent_collection()
-xent_context_collection = xent_collection('contexts')
-xe1t_runs_collection = xe1t_collection()
+class LazyInit:
+
+    def __init__(self, function, *args, **kwargs):
+        self._instance = None
+        self.function = function
+        self.args = args
+        self.kwargs = kwargs
+
+    def _init_instance(self):
+        if self._instance is None:
+            self._instance = function(*self.args, **self.kwargs)
+
+    def __getattr__(self, name):
+        self._init_instance()  # Initialize only when an attribute is accessed
+        return getattr(self._instance, name)
+
+
+xent_runs_collection = LazyInit(xent_collection)
+xent_context_collection = LazyInit(xent_collection, 'contexts')
+xe1t_runs_collection = LazyInit(xe1t_collection)
 
 
 RAW_DTYPES = ['raw_records',

--- a/admix/utils.py
+++ b/admix/utils.py
@@ -23,7 +23,7 @@ class LazyInit:
 
     def _init_instance(self):
         if self._instance is None:
-            self._instance = function(*self.args, **self.kwargs)
+            self._instance = self.function(*self.args, **self.kwargs)
 
     def __getattr__(self, name):
         self._init_instance()  # Initialize only when an attribute is accessed


### PR DESCRIPTION
Close https://github.com/XENONnT/admix/issues/58

The `LazyInit` will only initialize the instance only if the attribute or method of `pymongo.MongoClient` like `find`.