### PR TITLE
Prioritize downloading from disks at RCC

### DIFF
--- a/admix/downloader.py
+++ b/admix/downloader.py
@@ -28,7 +28,7 @@ class RucioDownloadError(Exception):
 def determine_rse(rse_list):
     # TODO put this in config or something?
 
-    preferred_host_rses = {'rcc': ['UC_DALI_USERDISK', 'UC_OSG_USERDISK', 'SDSC_USERDISK', 'SDSC_NSDF_USERDISK', 'SURFSARA2_USERDISK', 'NIKHEF2_USERDISK', 'CNAF_USERDISK'],
+    preferred_host_rses = {'rcc': ['UC_DALI_USERDISK', 'UC_OSG_USERDISK', 'SDSC_USERDISK', 'SDSC_NSDF_USERDISK', 'SURFSARA2_USERDISK', 'NIKHEF2_USERDISK', 'CNAF_USERDISK', 'CCIN2P32_USERDISK'],
                            'sdsc': ['SDSC_USERDISK', 'UC_OSG_USERDISK', 'UC_DALI_USERDISK', 'SDSC_NSDF_USERDISK'],
                            'in2p3': ['CCIN2P3_USERDISK', 'NIKHEF2_USERDISK', 'CNAF_USERDISK'],
                            'nikhef': ['NIKHEF2_USERDISK', 'SURFSARA_USERDISK', 'CNAF_USERDISK'],

--- a/admix/downloader.py
+++ b/admix/downloader.py
@@ -29,7 +29,7 @@ def determine_rse(rse_list):
     # TODO put this in config or something?
 
     preferred_host_rses = {'rcc': ['UC_DALI_USERDISK', 'UC_OSG_USERDISK', 'SDSC_USERDISK', 'SDSC_NSDF_USERDISK', 'SURFSARA2_USERDISK', 'NIKHEF2_USERDISK', 'CNAF_USERDISK', 'CCIN2P32_USERDISK'],
-                           'sdsc': ['SDSC_USERDISK', 'UC_OSG_USERDISK', 'UC_DALI_USERDISK', 'SDSC_NSDF_USERDISK'],
+                           'sdsc': ['SDSC_USERDISK', 'UC_OSG_USERDISK', 'UC_DALI_USERDISK', 'SDSC_NSDF_USERDISK', 'CCIN2P32_USERDISK'],
                            'in2p3': ['CCIN2P3_USERDISK', 'NIKHEF2_USERDISK', 'CNAF_USERDISK', 'CCIN2P32_USERDISK'],
                            'nikhef': ['NIKHEF2_USERDISK', 'SURFSARA_USERDISK', 'CNAF_USERDISK', 'CCIN2P32_USERDISK'],
                            'surf': ['SURFSARA2_USERDISK', 'SURFSARA_USERDISK', 'NIKHEF2_USERDISK', 'CNAF_USERDISK', 'CCIN2P32_USERDISK'],

--- a/admix/downloader.py
+++ b/admix/downloader.py
@@ -28,11 +28,11 @@ class RucioDownloadError(Exception):
 def determine_rse(rse_list):
     # TODO put this in config or something?
 
-    preferred_host_rses = {'rcc': ['UC_DALI_USERDISK', 'UC_OSG_USERDISK', 'SDSC_USERDISK', 'SDSC_NSDF_USERDISK'],
+    preferred_host_rses = {'rcc': ['UC_DALI_USERDISK', 'UC_OSG_USERDISK', 'SDSC_USERDISK', 'SDSC_NSDF_USERDISK', 'SURFSARA2_USERDISK', 'NIKHEF2_USERDISK', 'CNAF_USERDISK'],
                            'sdsc': ['SDSC_USERDISK', 'UC_OSG_USERDISK', 'UC_DALI_USERDISK', 'SDSC_NSDF_USERDISK'],
                            'in2p3': ['CCIN2P3_USERDISK', 'NIKHEF2_USERDISK', 'CNAF_USERDISK'],
                            'nikhef': ['NIKHEF2_USERDISK', 'SURFSARA_USERDISK', 'CNAF_USERDISK'],
-                           'surf': ['SURFSARA_USERDISK', 'NIKHEF2_USERDISK', 'CNAF_USERDISK'],
+                           'surf': ['SURFSARA2_USERDISK', 'SURFSARA_USERDISK', 'NIKHEF2_USERDISK', 'CNAF_USERDISK'],
                           }
 
     preferred_glidein_rses = {'US,CA':  ['UC_OSG_USERDISK', 'SDSC_USERDISK', 'UC_DALI_USERDISK', 'SDSC_NSDF_USERDISK'],

--- a/admix/downloader.py
+++ b/admix/downloader.py
@@ -30,13 +30,13 @@ def determine_rse(rse_list):
 
     preferred_host_rses = {'rcc': ['UC_DALI_USERDISK', 'UC_OSG_USERDISK', 'SDSC_USERDISK', 'SDSC_NSDF_USERDISK', 'SURFSARA2_USERDISK', 'NIKHEF2_USERDISK', 'CNAF_USERDISK', 'CCIN2P32_USERDISK'],
                            'sdsc': ['SDSC_USERDISK', 'UC_OSG_USERDISK', 'UC_DALI_USERDISK', 'SDSC_NSDF_USERDISK'],
-                           'in2p3': ['CCIN2P3_USERDISK', 'NIKHEF2_USERDISK', 'CNAF_USERDISK'],
-                           'nikhef': ['NIKHEF2_USERDISK', 'SURFSARA_USERDISK', 'CNAF_USERDISK'],
-                           'surf': ['SURFSARA2_USERDISK', 'SURFSARA_USERDISK', 'NIKHEF2_USERDISK', 'CNAF_USERDISK'],
+                           'in2p3': ['CCIN2P3_USERDISK', 'NIKHEF2_USERDISK', 'CNAF_USERDISK', 'CCIN2P32_USERDISK'],
+                           'nikhef': ['NIKHEF2_USERDISK', 'SURFSARA_USERDISK', 'CNAF_USERDISK', 'CCIN2P32_USERDISK'],
+                           'surf': ['SURFSARA2_USERDISK', 'SURFSARA_USERDISK', 'NIKHEF2_USERDISK', 'CNAF_USERDISK', 'CCIN2P32_USERDISK'],
                           }
 
     preferred_glidein_rses = {'US,CA':  ['UC_OSG_USERDISK', 'SDSC_USERDISK', 'UC_DALI_USERDISK', 'SDSC_NSDF_USERDISK'],
-                              'EUROPE,NL,IT,FR,IL': ['NIKHEF2_USERDISK', 'CNAF_USERDISK', 'SURFSARA_USERDISK']
+                              'EUROPE,NL,IT,FR,IL': ['NIKHEF2_USERDISK', 'CNAF_USERDISK', 'SURFSARA_USERDISK', 'CCIN2P32_USERDISK']
                               }
 
     hostname = socket.getfqdn()


### PR DESCRIPTION
Currently, admix does not (fully) know which RSE is tape and which is disk. It is sort of managed by hardcoded preference [here](https://github.com/XENONnT/admix/blob/23ee818c44b75f0c23873ea22baf53e2e867e1f7/admix/downloader.py#L31-L40), based on glidein and host, which is fair. 

It happens that when people are in the US (running on RCC), they try to download data that only exists in Europe. However, currently admix does NOT know to prioritize downloading from disk, if there is a disk copy among multiple tape copies. This causes trouble like downloading forever from tape, when a disk copy is actually available. 

This PR is a quick patch so that,

- When there is a disk copy, even though you are in the US and the disk is in EU, prioritize the downloading from EU.
- In SURFSARA, prioritize disk `SURFSARA2_USERDISK` over other tapes.