### PR TITLE
Debug RunDB update when rucio upload failed

### DIFF
--- a/admix/uploader.py
+++ b/admix/uploader.py
@@ -120,17 +120,19 @@ def upload(
                     )
 
     if len(to_upload):
+        upload_success = False
         if update_db:
             db.update_data(number, data_dict)
         try:
             clients.upload_client.upload(to_upload)
+            upload_success = True
         except Exception as e:
             if verbose:
                 print(f"Upload failed for {path}")
                 print(e)
             return did
         # then update db again when complete
-        if update_db:
+        if update_db and upload_success:
             data_dict['status'] = 'transferred'
             # get files, size etc
             files = list_files(did, verbose=True)


### PR DESCRIPTION
In the current implementation, it seems that even though for some weird reason `clients.upload_client.upload(to_upload)` failed, we are still updating the DB anyway as if the data has been delivered. This simply will lead to a mismatch between RunDB and rucio when rucio fails.