### PR TITLE
Force raising exception when upload failed

### DIFF
--- a/admix/uploader.py
+++ b/admix/uploader.py
@@ -128,7 +128,7 @@ def upload(
             if verbose:
                 print(f"Upload failed for {path}")
                 print(e)
-            return did
+            raise
         # then update db again when complete
         if update_db:
             data_dict['status'] = 'transferred'


### PR DESCRIPTION
A stupid bug was introduced by me in #40. The issue is that, when upload failed, it won't raise error, and will just keep going as if no problem happened. Now it is fixed, in the sense that the rucio error will be raised at least.