### PR TITLE
Allow missing gfal2

### DIFF
--- a/admix/manager.py
+++ b/admix/manager.py
@@ -15,9 +15,15 @@ from . import rucio, logger
 from . import utils
 from .utils import db
 
-import gfal2
 import time
 from datetime import timezone, datetime, timedelta
+
+try:
+    import gfal2
+
+    HAVE_GFAL2 = True
+except (ImportError, AttributeError):
+    HAVE_GFAL2 = False
 
 TAPE_RSES = ['SURFSARA_USERDISK','CNAF_TAPE3_USERDISK','CNAF_TAPE2_USERDISK','CNAF_TAPE_USERDISK','CCIN2P3_USERDISK']
 


### PR DESCRIPTION
gfal2 because it is only called in `bring_online`. Sometimes in RHEL7 you will see error

```
ImportError: libgfal2.so.2: cannot open shared object file: No such file or directory
```

because some lib is missing. But we do not always need gfal2.